### PR TITLE
feat: Defense-in-depth private key protection for notebooks and logs

### DIFF
--- a/freqtrade/config_schema/config_schema.py
+++ b/freqtrade/config_schema/config_schema.py
@@ -874,8 +874,18 @@ CONF_SCHEMA = {
                 },
                 "private_key": {
                     "description": (
-                        "Private key for the exchange, if required. Usually used by DEX exchanges. "
+                        "DEPRECATED: Raw private keys in config files are a security risk. "
+                        "Use 'private_key_env' instead to reference an environment variable. "
                         f"{__VIA_ENV} FREQTRADE__EXCHANGE__PRIVATE_KEY"
+                    ),
+                    "type": "string",
+                },
+                "private_key_env": {
+                    "description": (
+                        "Name of the environment variable containing the private key. "
+                        "The key is resolved at runtime and never stored in config. "
+                        "Example: \"GMX_PRIVATE_KEY\". "
+                        f"{__VIA_ENV} FREQTRADE__EXCHANGE__PRIVATE_KEY_ENV"
                     ),
                     "type": "string",
                 },

--- a/freqtrade/configuration/config_validation.py
+++ b/freqtrade/configuration/config_validation.py
@@ -79,6 +79,9 @@ def validate_config_consistency(conf: dict[str, Any], *, preliminary: bool = Fal
     :return: Returns None if everything is ok, otherwise throw an ConfigurationError
     """
 
+    # Reject raw private keys before any other validation can echo the value
+    _validate_no_raw_private_keys(conf)
+
     # validating trailing stoploss
     _validate_trailing_stoploss(conf)
     _validate_price_config(conf)
@@ -96,6 +99,39 @@ def validate_config_consistency(conf: dict[str, Any], *, preliminary: bool = Fal
     # validate configuration before returning
     logger.info("Validating configuration ...")
     validate_config_schema(conf, preliminary=preliminary)
+
+
+def _validate_no_raw_private_keys(conf: dict[str, Any]) -> None:
+    """
+    Reject configurations that contain raw private keys.
+
+    Raw private keys must never appear in config files. Use ``private_key_env``
+    to reference an environment variable instead.
+    """
+    exchange_conf = conf.get("exchange", {})
+
+    # Check top-level exchange fields
+    for field in ("private_key", "privateKey"):
+        if exchange_conf.get(field):
+            raise ConfigurationError(
+                f"Raw private key found in exchange.{field}. "
+                "This is a security risk — private keys must not be stored in config files. "
+                "Use 'private_key_env' to specify an environment variable name instead. "
+                "Example: \"private_key_env\": \"GMX_PRIVATE_KEY\""
+            )
+
+    # Check nested ccxt config sections
+    for section in ("ccxt_config", "ccxt_sync_config", "ccxt_async_config"):
+        nested = exchange_conf.get(section, {})
+        if isinstance(nested, dict):
+            for field in ("privateKey", "private_key"):
+                if nested.get(field):
+                    raise ConfigurationError(
+                        f"Raw private key found in exchange.{section}.{field}. "
+                        "This is a security risk — private keys must not be stored in "
+                        "config files. Use 'private_key_env' at the exchange level instead. "
+                        "Example: \"private_key_env\": \"GMX_PRIVATE_KEY\""
+                    )
 
 
 def _validate_unlimited_amount(conf: dict[str, Any]) -> None:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -397,7 +397,7 @@ class Exchange:
             "walletAddress": exchange_config.get(
                 "wallet_address", exchange_config.get("walletAddress")
             ),
-            "privateKey": exchange_config.get("private_key", exchange_config.get("privateKey")),
+            "privateKey": self._resolve_private_key(exchange_config),
         }
         if ccxt_kwargs:
             logger.info("Applying additional ccxt config: %s", ccxt_kwargs)
@@ -414,6 +414,30 @@ class Exchange:
             raise OperationalException(f"Initialization of ccxt failed. Reason: {e}") from e
 
         return api
+
+    @staticmethod
+    def _resolve_private_key(exchange_config: dict) -> str | None:
+        """
+        Resolve the private key from environment variable or legacy config field.
+
+        Preferred: ``private_key_env`` — name of an env var holding the key.
+        Legacy fallback: ``private_key`` / ``privateKey`` — still accepted for
+        backwards compatibility but rejected by config validation when set in files.
+        """
+        env_var_name = exchange_config.get("private_key_env")
+        if env_var_name:
+            import os
+
+            value = os.environ.get(env_var_name)
+            if not value:
+                raise OperationalException(
+                    f"private_key_env is set to '{env_var_name}' but the environment "
+                    f"variable is not set or is empty."
+                )
+            return value
+        # Legacy fallback — config validation will reject raw keys in files,
+        # but programmatic callers may still pass them in-memory.
+        return exchange_config.get("private_key", exchange_config.get("privateKey"))
 
     @property
     def _ccxt_config(self) -> dict:

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -11,7 +11,7 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.loggers.buffering_handler import FTBufferingHandler
 from freqtrade.loggers.ft_rich_handler import FtRichHandler
 from freqtrade.loggers.rich_console import get_rich_console
-from freqtrade.loggers.sensitive_filter import SensitiveDataFilter, patch_logging
+from freqtrade.loggers.sensitive_filter import patch_logging
 
 
 # from freqtrade.loggers.std_err_stream_handler import FTStdErrStreamHandler

--- a/freqtrade/loggers/__init__.py
+++ b/freqtrade/loggers/__init__.py
@@ -11,7 +11,7 @@ from freqtrade.exceptions import OperationalException
 from freqtrade.loggers.buffering_handler import FTBufferingHandler
 from freqtrade.loggers.ft_rich_handler import FtRichHandler
 from freqtrade.loggers.rich_console import get_rich_console
-from freqtrade.loggers.sensitive_filter import SensitiveDataFilter
+from freqtrade.loggers.sensitive_filter import SensitiveDataFilter, patch_logging
 
 
 # from freqtrade.loggers.std_err_stream_handler import FTStdErrStreamHandler
@@ -215,10 +215,8 @@ def setup_logging(config: Config) -> None:
 
         logging.config.dictConfig(log_config)
 
-        # Add sensitive data filter to all handlers
-        sensitive_filter = SensitiveDataFilter()
-        for handler in logging.root.handlers:
-            handler.addFilter(sensitive_filter)
+        # Add sensitive data filter to all handlers and install LogRecordFactory
+        patch_logging()
 
     # Add buffer handler to root logger
     if bufferHandler not in logging.root.handlers:

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -38,11 +38,11 @@ class SensitiveDataFilter(logging.Filter):
         # Passwords (any non-empty value)
         (r"'password':\s*'([^']+)'", r"'password': '[REDACTED]'"),
         (r'"password":\s*"([^"]+)"', r'"password": "[REDACTED]"'),
-        # Private keys (64+ char hex strings) — keyed format
-        (r"'privateKey':\s*'(0x[0-9a-fA-F]{64,})'", r"'privateKey': '[REDACTED]'"),
-        (r'"privateKey":\s*"(0x[0-9a-fA-F]{64,})"', r'"privateKey": "[REDACTED]"'),
-        (r"'private_key':\s*'(0x[0-9a-fA-F]{64,})'", r"'private_key': '[REDACTED]'"),
-        (r'"private_key":\s*"(0x[0-9a-fA-F]{64,})"', r'"private_key": "[REDACTED]"'),
+        # Private keys (64+ char hex, optionally 0x-prefixed) — keyed format
+        (r"'privateKey':\s*'(?:0x)?([0-9a-fA-F]{64,})'", r"'privateKey': '[REDACTED]'"),
+        (r'"privateKey":\s*"(?:0x)?([0-9a-fA-F]{64,})"', r'"privateKey": "[REDACTED]"'),
+        (r"'private_key':\s*'(?:0x)?([0-9a-fA-F]{64,})'", r"'private_key': '[REDACTED]'"),
+        (r'"private_key":\s*"(?:0x)?([0-9a-fA-F]{64,})"', r'"private_key": "[REDACTED]"'),
         # Account IDs (hex addresses, 40+ chars)
         (r"'accountId':\s*'(0x[0-9a-fA-F]{40,})'", r"'accountId': '[REDACTED]'"),
         (r'"accountId":\s*"(0x[0-9a-fA-F]{40,})"', r'"accountId": "[REDACTED]"'),

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -338,22 +338,28 @@ def is_notebook_patched() -> bool:
 _LOGGING_PATCHED = False
 _SENSITIVE_FILTER: SensitiveDataFilter | None = None
 _ORIGINAL_HANDLER_INIT = None
+_ORIGINAL_RECORD_FACTORY = None
+_ORIGINAL_FORMAT_EXCEPTION = None
 
 
 def patch_logging() -> None:
     """Add SensitiveDataFilter to all existing and future log handlers.
 
-    Also installs a custom LogRecordFactory so that sanitization happens
-    *before* any handler sees the record, closing the buffer/RPC blind spot.
+    Also installs:
+    - A custom LogRecordFactory so msg/args are sanitized before handlers
+    - A Formatter.formatException wrapper so exc_text is sanitized when
+      generated (exc_text is populated lazily, so the factory can't catch it)
 
     Safe to call multiple times — will only apply once.
     """
     global _LOGGING_PATCHED, _SENSITIVE_FILTER, _ORIGINAL_HANDLER_INIT
+    global _ORIGINAL_RECORD_FACTORY, _ORIGINAL_FORMAT_EXCEPTION
 
     if _LOGGING_PATCHED:
         return
 
     _SENSITIVE_FILTER = SensitiveDataFilter()
+    compiled = _get_default_compiled_patterns()
 
     # Add filter to all existing handlers
     for handler in logging.root.handlers:
@@ -369,8 +375,20 @@ def patch_logging() -> None:
 
     logging.Handler.__init__ = patched_handler_init
 
-    # Install a custom LogRecordFactory for pre-handler sanitization
-    _install_sanitizing_record_factory()
+    # Install a custom LogRecordFactory for pre-handler sanitization of msg/args
+    _ORIGINAL_RECORD_FACTORY = logging.getLogRecordFactory()
+    _install_sanitizing_record_factory(_ORIGINAL_RECORD_FACTORY)
+
+    # Patch Formatter.formatException so exc_text is sanitized when generated.
+    # exc_text is populated lazily during format() — after both the factory
+    # and filter have already run — so it must be caught at the source.
+    _ORIGINAL_FORMAT_EXCEPTION = logging.Formatter.formatException
+
+    def sanitized_format_exception(self, ei):
+        text = _ORIGINAL_FORMAT_EXCEPTION(self, ei)
+        return sanitize_text(text, compiled)
+
+    logging.Formatter.formatException = sanitized_format_exception
 
     _LOGGING_PATCHED = True
 
@@ -378,12 +396,21 @@ def patch_logging() -> None:
 def unpatch_logging() -> None:
     """Remove the logging monkeypatch. Mainly useful for testing."""
     global _LOGGING_PATCHED, _SENSITIVE_FILTER, _ORIGINAL_HANDLER_INIT
+    global _ORIGINAL_RECORD_FACTORY, _ORIGINAL_FORMAT_EXCEPTION
 
     if not _LOGGING_PATCHED:
         return
 
     if _ORIGINAL_HANDLER_INIT is not None:
         logging.Handler.__init__ = _ORIGINAL_HANDLER_INIT
+
+    # Restore original LogRecordFactory
+    if _ORIGINAL_RECORD_FACTORY is not None:
+        logging.setLogRecordFactory(_ORIGINAL_RECORD_FACTORY)
+
+    # Restore original Formatter.formatException
+    if _ORIGINAL_FORMAT_EXCEPTION is not None:
+        logging.Formatter.formatException = _ORIGINAL_FORMAT_EXCEPTION
 
     # Remove filter from existing handlers
     if _SENSITIVE_FILTER is not None:
@@ -393,6 +420,8 @@ def unpatch_logging() -> None:
     _LOGGING_PATCHED = False
     _SENSITIVE_FILTER = None
     _ORIGINAL_HANDLER_INIT = None
+    _ORIGINAL_RECORD_FACTORY = None
+    _ORIGINAL_FORMAT_EXCEPTION = None
 
 
 def is_logging_patched() -> bool:
@@ -427,13 +456,17 @@ def _sanitize_any(value: Any, compiled_patterns: list) -> str | Any:
     return value
 
 
-def _install_sanitizing_record_factory() -> None:
+def _install_sanitizing_record_factory(original_factory) -> None:
     """Wrap the current LogRecordFactory so every record is sanitized at creation.
 
     This ensures sanitization happens *before* any handler or filter sees
-    the record, closing the FTBufferingHandler / RPC blind spot.
+    the record, closing the FTBufferingHandler / RPC blind spot where
+    ``exc_text`` and ``message`` are read verbatim from the buffer.
+
+    The factory only sanitizes string values within existing arg structures —
+    it never converts a dict to a tuple, which would break ``%(name)s``
+    formatting and cause ``KeyError``.
     """
-    original_factory = logging.getLogRecordFactory()
     compiled = _get_default_compiled_patterns()
 
     def sanitizing_factory(*args, **kwargs):
@@ -442,15 +475,18 @@ def _install_sanitizing_record_factory() -> None:
             record.msg = sanitize_text(record.msg, compiled)
         if record.args:
             if isinstance(record.args, dict):
-                msg = record.msg if record.msg else ""
-                if "%s" in msg and "%(" not in msg:
-                    record.args = (sanitize_text(str(record.args), compiled),)
-                else:
-                    record.args = {
-                        k: _sanitize_any(v, compiled) for k, v in record.args.items()
-                    }
+                # Always preserve dict shape — never convert to tuple.
+                # This handles both %(name)s named args and single-dict %s args.
+                # The handler-level Filter handles the %s-with-dict edge case.
+                record.args = {
+                    k: _sanitize_any(v, compiled) for k, v in record.args.items()
+                }
             elif isinstance(record.args, tuple):
                 record.args = tuple(_sanitize_any(a, compiled) for a in record.args)
+        # Sanitize exception text — this is what _rpc_get_logs reads from
+        # bufferHandler.buffer[].exc_text verbatim.
+        if record.exc_text and isinstance(record.exc_text, str):
+            record.exc_text = sanitize_text(record.exc_text, compiled)
         return record
 
     logging.setLogRecordFactory(sanitizing_factory)

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -4,10 +4,9 @@ import sys
 from typing import Any
 
 
-# Bare private key pattern: 0x followed by exactly 64 hex chars (256-bit key),
-# but NOT longer (which would be a signature or tx hash).
+# Bare private key pattern: optionally 0x-prefixed, exactly 64 hex chars (256-bit key).
 # Uses word boundary to avoid matching inside longer hex strings.
-_BARE_HEX_KEY_RE = re.compile(r"\b0x[0-9a-fA-F]{64}\b")
+_BARE_HEX_KEY_RE = re.compile(r"\b(?:0x)?[0-9a-fA-F]{64}\b")
 
 # PEM private key blocks
 _PEM_KEY_RE = re.compile(

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -1,6 +1,24 @@
 import logging
 import re
+import sys
 from typing import Any
+
+
+# Bare private key pattern: 0x followed by exactly 64 hex chars (256-bit key),
+# but NOT longer (which would be a signature or tx hash).
+# Uses word boundary to avoid matching inside longer hex strings.
+_BARE_HEX_KEY_RE = re.compile(r"\b0x[0-9a-fA-F]{64}\b")
+
+# PEM private key blocks
+_PEM_KEY_RE = re.compile(
+    r"-----BEGIN (?:EC |RSA |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----"
+    r"[\s\S]*?"
+    r"-----END (?:EC |RSA |DSA |OPENSSH |ENCRYPTED )?PRIVATE KEY-----",
+    re.MULTILINE,
+)
+
+# ed25519 secret format used in this repo (e.g., "ed25519:JC5mjh84Gki...")
+_ED25519_SECRET_RE = re.compile(r"ed25519:[A-Za-z0-9+/=]{32,}")
 
 
 class SensitiveDataFilter(logging.Filter):
@@ -10,7 +28,7 @@ class SensitiveDataFilter(logging.Filter):
     """
 
     # Patterns to redact: (regex_pattern, replacement)
-    # Matches key="value" or key: "value" patterns
+    # Matches key="value" or key: "value" patterns in Python dict repr / JSON
     PATTERNS: list[tuple[str, str]] = [
         # API keys (16+ char strings) - Python dict repr format: 'apiKey': 'value'
         (r"'apiKey':\s*'([^']{16,})'", r"'apiKey': '[REDACTED]'"),
@@ -21,7 +39,7 @@ class SensitiveDataFilter(logging.Filter):
         # Passwords (any non-empty value)
         (r"'password':\s*'([^']+)'", r"'password': '[REDACTED]'"),
         (r'"password":\s*"([^"]+)"', r'"password": "[REDACTED]"'),
-        # Private keys (64+ char hex strings)
+        # Private keys (64+ char hex strings) — keyed format
         (r"'privateKey':\s*'(0x[0-9a-fA-F]{64,})'", r"'privateKey': '[REDACTED]'"),
         (r'"privateKey":\s*"(0x[0-9a-fA-F]{64,})"', r'"privateKey": "[REDACTED]"'),
         (r"'private_key':\s*'(0x[0-9a-fA-F]{64,})'", r"'private_key': '[REDACTED]'"),
@@ -49,11 +67,15 @@ class SensitiveDataFilter(logging.Filter):
             for pattern, replacement in self.PATTERNS
         ]
 
+    def _sanitize(self, text: str) -> str:
+        """Apply all redaction patterns to the text (instance convenience method)."""
+        return sanitize_text(text, self._compiled_patterns)
+
     def filter(self, record: logging.LogRecord) -> bool:
         """Filter and sanitize the log record message."""
         # Sanitize the message
         if record.msg and isinstance(record.msg, str):
-            record.msg = self._sanitize(record.msg)
+            record.msg = sanitize_text(record.msg, self._compiled_patterns)
 
         # Sanitize arguments
         # record.args can be a tuple or a dict
@@ -70,28 +92,365 @@ class SensitiveDataFilter(logging.Filter):
                 msg = record.msg if record.msg else ""
                 if "%s" in msg and "%(" not in msg:
                     # Single dict arg for %s formatting - convert to sanitized string tuple
-                    record.args = (self._sanitize(str(record.args)),)
+                    record.args = (sanitize_text(str(record.args), self._compiled_patterns),)
                 else:
                     # Named args for %(name)s formatting - sanitize each value
                     record.args = {
-                        k: self._sanitize_any(v) for k, v in record.args.items()
+                        k: _sanitize_any(v, self._compiled_patterns)
+                        for k, v in record.args.items()
                     }
             elif isinstance(record.args, tuple):
-                record.args = tuple(self._sanitize_any(arg) for arg in record.args)
+                record.args = tuple(
+                    _sanitize_any(arg, self._compiled_patterns) for arg in record.args
+                )
+
+        # Sanitize exception text if present
+        if record.exc_text:
+            record.exc_text = sanitize_text(record.exc_text, self._compiled_patterns)
+
         return True  # Always return True to keep the record
 
-    def _sanitize_any(self, value: Any) -> str | Any:
-        """Sanitize any value, converting non-strings to string first if needed."""
-        if isinstance(value, str):
-            return self._sanitize(value)
-        elif isinstance(value, (dict, list)):
-            # Convert to string repr, then sanitize
-            return self._sanitize(str(value))
-        else:
-            return value
 
-    def _sanitize(self, text: str) -> str:
-        """Apply all redaction patterns to the text."""
-        for pattern, replacement in self._compiled_patterns:
-            text = pattern.sub(replacement, text)
-        return text
+# ---------------------------------------------------------------------------
+# Public helpers — usable outside of the logging.Filter pathway
+# ---------------------------------------------------------------------------
+
+def sanitize_text(text: str, compiled_patterns: list | None = None) -> str:
+    """Apply all redaction patterns to a string.
+
+    This is the single sanitization entry point used by log filters,
+    notebook patches, git hooks, and save guards.
+    """
+    if compiled_patterns is None:
+        compiled_patterns = _get_default_compiled_patterns()
+
+    for pattern, replacement in compiled_patterns:
+        text = pattern.sub(replacement, text)
+
+    # Bare hex private keys (not already caught by keyed patterns)
+    text = _BARE_HEX_KEY_RE.sub("[REDACTED-KEY]", text)
+    # PEM private key blocks
+    text = _PEM_KEY_RE.sub("[REDACTED-PEM-KEY]", text)
+    # ed25519 secrets
+    text = _ED25519_SECRET_RE.sub("[REDACTED-ED25519]", text)
+    return text
+
+
+def contains_secret(text: str) -> bool:
+    """Return True if *text* contains anything that looks like a secret.
+
+    Unlike ``sanitize_text`` this does **not** modify the text — it is a
+    pure detection function used by save hooks and git scanners to decide
+    whether to block an operation.
+    """
+    if _BARE_HEX_KEY_RE.search(text):
+        return True
+    if _PEM_KEY_RE.search(text):
+        return True
+    if _ED25519_SECRET_RE.search(text):
+        return True
+    # Check keyed patterns
+    for pattern, _ in _get_default_compiled_patterns():
+        if pattern.search(text):
+            return True
+    return False
+
+
+def sanitize_mime_bundle(data: dict[str, Any]) -> dict[str, Any]:
+    """Sanitize a Jupyter MIME bundle dict (e.g. from display_data messages).
+
+    Only string values are filtered; binary payloads (images) are left alone.
+    """
+    compiled = _get_default_compiled_patterns()
+    result = {}
+    for mime_type, value in data.items():
+        if isinstance(value, str):
+            result[mime_type] = sanitize_text(value, compiled)
+        elif isinstance(value, list):
+            result[mime_type] = [
+                sanitize_text(item, compiled) if isinstance(item, str) else item
+                for item in value
+            ]
+        else:
+            result[mime_type] = value
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Notebook runtime patching
+# ---------------------------------------------------------------------------
+
+_NOTEBOOK_PATCHED = False
+_ORIGINAL_STDOUT_WRITE = None
+_ORIGINAL_STDERR_WRITE = None
+_ORIGINAL_WRITE_FORMAT_DATA = None
+_ORIGINAL_PUBLISH_DISPLAY_DATA = None
+_ORIGINAL_SHOWTRACEBACK = None
+
+
+def patch_notebook() -> None:
+    """Extend sensitive data filtering to all Jupyter/IPython output channels.
+
+    Patches:
+    1. sys.stdout.write / sys.stderr.write — catches print()
+    2. DisplayHook.write_format_data — catches last-expression auto-display
+    3. publish_display_data — catches display() / rich objects
+    4. InteractiveShell.showtraceback — catches leaked locals in tracebacks
+
+    Safe to call multiple times. No-op if IPython is not running.
+    """
+    global _NOTEBOOK_PATCHED
+    global _ORIGINAL_STDOUT_WRITE, _ORIGINAL_STDERR_WRITE
+    global _ORIGINAL_WRITE_FORMAT_DATA, _ORIGINAL_PUBLISH_DISPLAY_DATA
+    global _ORIGINAL_SHOWTRACEBACK
+
+    if _NOTEBOOK_PATCHED:
+        return
+
+    try:
+        from IPython import get_ipython
+        ipython = get_ipython()
+        if ipython is None:
+            return  # Not running inside IPython/Jupyter
+    except ImportError:
+        return  # IPython not installed
+
+    compiled = _get_default_compiled_patterns()
+
+    # --- Channel 1: stdout / stderr ---
+    _ORIGINAL_STDOUT_WRITE = sys.stdout.write
+    _ORIGINAL_STDERR_WRITE = sys.stderr.write
+
+    def _sanitized_stdout_write(text):
+        if isinstance(text, str):
+            text = sanitize_text(text, compiled)
+        return _ORIGINAL_STDOUT_WRITE(text)
+
+    def _sanitized_stderr_write(text):
+        if isinstance(text, str):
+            text = sanitize_text(text, compiled)
+        return _ORIGINAL_STDERR_WRITE(text)
+
+    sys.stdout.write = _sanitized_stdout_write
+    sys.stderr.write = _sanitized_stderr_write
+
+    # --- Channel 2: DisplayHook (last-expression auto-display) ---
+    if hasattr(ipython, "displayhook") and hasattr(ipython.displayhook, "write_format_data"):
+        _ORIGINAL_WRITE_FORMAT_DATA = ipython.displayhook.write_format_data
+
+        def _sanitized_write_format_data(format_dict, md_dict=None):
+            format_dict = sanitize_mime_bundle(format_dict)
+            return _ORIGINAL_WRITE_FORMAT_DATA(format_dict, md_dict)
+
+        ipython.displayhook.write_format_data = _sanitized_write_format_data
+
+    # --- Channel 3: publish_display_data (display() calls) ---
+    try:
+        import IPython.core.display_functions as _display_mod
+
+        _ORIGINAL_PUBLISH_DISPLAY_DATA = _display_mod.publish_display_data
+
+        def _sanitized_publish_display_data(data, metadata=None, *, transient=None, **kwargs):
+            if isinstance(data, dict):
+                data = sanitize_mime_bundle(data)
+            return _ORIGINAL_PUBLISH_DISPLAY_DATA(
+                data, metadata, transient=transient, **kwargs
+            )
+
+        _display_mod.publish_display_data = _sanitized_publish_display_data
+    except (ImportError, AttributeError):
+        pass
+
+    # --- Channel 4: Traceback display ---
+    if hasattr(ipython, "showtraceback"):
+        _ORIGINAL_SHOWTRACEBACK = ipython.showtraceback
+
+        def _sanitized_showtraceback(*args, **kwargs):
+            # Capture the traceback output by temporarily redirecting stderr
+            import io
+            buf = io.StringIO()
+            old_stderr = sys.stderr
+            # Temporarily bypass our stderr patch to avoid double-sanitizing
+            sys.stderr = buf
+            try:
+                _ORIGINAL_SHOWTRACEBACK(*args, **kwargs)
+            finally:
+                sys.stderr = old_stderr
+            sanitized = sanitize_text(buf.getvalue(), compiled)
+            if sanitized:
+                old_stderr.write(sanitized)
+
+        ipython.showtraceback = _sanitized_showtraceback
+
+    _NOTEBOOK_PATCHED = True
+
+
+def unpatch_notebook() -> None:
+    """Remove all notebook output patches. Mainly useful for testing."""
+    global _NOTEBOOK_PATCHED
+    global _ORIGINAL_STDOUT_WRITE, _ORIGINAL_STDERR_WRITE
+    global _ORIGINAL_WRITE_FORMAT_DATA, _ORIGINAL_PUBLISH_DISPLAY_DATA
+    global _ORIGINAL_SHOWTRACEBACK
+
+    if not _NOTEBOOK_PATCHED:
+        return
+
+    if _ORIGINAL_STDOUT_WRITE is not None:
+        sys.stdout.write = _ORIGINAL_STDOUT_WRITE
+    if _ORIGINAL_STDERR_WRITE is not None:
+        sys.stderr.write = _ORIGINAL_STDERR_WRITE
+
+    try:
+        from IPython import get_ipython
+        ipython = get_ipython()
+        if ipython is not None:
+            if _ORIGINAL_WRITE_FORMAT_DATA is not None:
+                ipython.displayhook.write_format_data = _ORIGINAL_WRITE_FORMAT_DATA
+            if _ORIGINAL_SHOWTRACEBACK is not None:
+                ipython.showtraceback = _ORIGINAL_SHOWTRACEBACK
+    except ImportError:
+        pass
+
+    if _ORIGINAL_PUBLISH_DISPLAY_DATA is not None:
+        try:
+            import IPython.core.display_functions as _display_mod
+            _display_mod.publish_display_data = _ORIGINAL_PUBLISH_DISPLAY_DATA
+        except (ImportError, AttributeError):
+            pass
+
+    _NOTEBOOK_PATCHED = False
+    _ORIGINAL_STDOUT_WRITE = None
+    _ORIGINAL_STDERR_WRITE = None
+    _ORIGINAL_WRITE_FORMAT_DATA = None
+    _ORIGINAL_PUBLISH_DISPLAY_DATA = None
+    _ORIGINAL_SHOWTRACEBACK = None
+
+
+def is_notebook_patched() -> bool:
+    """Check if notebook output channels have been patched."""
+    return _NOTEBOOK_PATCHED
+
+
+# ---------------------------------------------------------------------------
+# Logging monkeypatch (mirrors web3-ethereum-defi version)
+# ---------------------------------------------------------------------------
+
+_LOGGING_PATCHED = False
+_SENSITIVE_FILTER: SensitiveDataFilter | None = None
+_ORIGINAL_HANDLER_INIT = None
+
+
+def patch_logging() -> None:
+    """Add SensitiveDataFilter to all existing and future log handlers.
+
+    Also installs a custom LogRecordFactory so that sanitization happens
+    *before* any handler sees the record, closing the buffer/RPC blind spot.
+
+    Safe to call multiple times — will only apply once.
+    """
+    global _LOGGING_PATCHED, _SENSITIVE_FILTER, _ORIGINAL_HANDLER_INIT
+
+    if _LOGGING_PATCHED:
+        return
+
+    _SENSITIVE_FILTER = SensitiveDataFilter()
+
+    # Add filter to all existing handlers
+    for handler in logging.root.handlers:
+        handler.addFilter(_SENSITIVE_FILTER)
+
+    # Monkeypatch logging.Handler.__init__ to add filter to future handlers
+    _ORIGINAL_HANDLER_INIT = logging.Handler.__init__
+
+    def patched_handler_init(self, level=logging.NOTSET):
+        _ORIGINAL_HANDLER_INIT(self, level)
+        if _SENSITIVE_FILTER is not None:
+            self.addFilter(_SENSITIVE_FILTER)
+
+    logging.Handler.__init__ = patched_handler_init
+
+    # Install a custom LogRecordFactory for pre-handler sanitization
+    _install_sanitizing_record_factory()
+
+    _LOGGING_PATCHED = True
+
+
+def unpatch_logging() -> None:
+    """Remove the logging monkeypatch. Mainly useful for testing."""
+    global _LOGGING_PATCHED, _SENSITIVE_FILTER, _ORIGINAL_HANDLER_INIT
+
+    if not _LOGGING_PATCHED:
+        return
+
+    if _ORIGINAL_HANDLER_INIT is not None:
+        logging.Handler.__init__ = _ORIGINAL_HANDLER_INIT
+
+    # Remove filter from existing handlers
+    if _SENSITIVE_FILTER is not None:
+        for handler in logging.root.handlers:
+            handler.removeFilter(_SENSITIVE_FILTER)
+
+    _LOGGING_PATCHED = False
+    _SENSITIVE_FILTER = None
+    _ORIGINAL_HANDLER_INIT = None
+
+
+def is_logging_patched() -> bool:
+    """Check if logging has been patched with SensitiveDataFilter."""
+    return _LOGGING_PATCHED
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+_DEFAULT_COMPILED_PATTERNS: list | None = None
+
+
+def _get_default_compiled_patterns() -> list:
+    """Lazily compile and cache the default redaction patterns."""
+    global _DEFAULT_COMPILED_PATTERNS
+    if _DEFAULT_COMPILED_PATTERNS is None:
+        _DEFAULT_COMPILED_PATTERNS = [
+            (re.compile(pattern, re.IGNORECASE), replacement)
+            for pattern, replacement in SensitiveDataFilter.PATTERNS
+        ]
+    return _DEFAULT_COMPILED_PATTERNS
+
+
+def _sanitize_any(value: Any, compiled_patterns: list) -> str | Any:
+    """Sanitize any value, converting non-strings to string first if needed."""
+    if isinstance(value, str):
+        return sanitize_text(value, compiled_patterns)
+    elif isinstance(value, (dict, list)):
+        return sanitize_text(str(value), compiled_patterns)
+    return value
+
+
+def _install_sanitizing_record_factory() -> None:
+    """Wrap the current LogRecordFactory so every record is sanitized at creation.
+
+    This ensures sanitization happens *before* any handler or filter sees
+    the record, closing the FTBufferingHandler / RPC blind spot.
+    """
+    original_factory = logging.getLogRecordFactory()
+    compiled = _get_default_compiled_patterns()
+
+    def sanitizing_factory(*args, **kwargs):
+        record = original_factory(*args, **kwargs)
+        if record.msg and isinstance(record.msg, str):
+            record.msg = sanitize_text(record.msg, compiled)
+        if record.args:
+            if isinstance(record.args, dict):
+                msg = record.msg if record.msg else ""
+                if "%s" in msg and "%(" not in msg:
+                    record.args = (sanitize_text(str(record.args), compiled),)
+                else:
+                    record.args = {
+                        k: _sanitize_any(v, compiled) for k, v in record.args.items()
+                    }
+            elif isinstance(record.args, tuple):
+                record.args = tuple(_sanitize_any(a, compiled) for a in record.args)
+        return record
+
+    logging.setLogRecordFactory(sanitizing_factory)

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -230,8 +230,8 @@ def patch_notebook() -> None:
             text = sanitize_text(text, compiled)
         return _ORIGINAL_STDERR_WRITE(text)
 
-    sys.stdout.write = _sanitized_stdout_write
-    sys.stderr.write = _sanitized_stderr_write
+    sys.stdout.write = _sanitized_stdout_write  # type: ignore[method-assign]
+    sys.stderr.write = _sanitized_stderr_write  # type: ignore[method-assign]
 
     # --- Channel 2: DisplayHook (last-expression auto-display) ---
     if hasattr(ipython, "displayhook") and hasattr(ipython.displayhook, "write_format_data"):
@@ -241,7 +241,7 @@ def patch_notebook() -> None:
             format_dict = sanitize_mime_bundle(format_dict)
             return _ORIGINAL_WRITE_FORMAT_DATA(format_dict, md_dict)
 
-        ipython.displayhook.write_format_data = _sanitized_write_format_data
+        ipython.displayhook.write_format_data = _sanitized_write_format_data  # type: ignore[method-assign]
 
     # --- Channel 3: publish_display_data (display() calls) ---
     try:
@@ -256,7 +256,7 @@ def patch_notebook() -> None:
                 data, metadata, transient=transient, **kwargs
             )
 
-        _display_mod.publish_display_data = _sanitized_publish_display_data
+        _display_mod.publish_display_data = _sanitized_publish_display_data  # type: ignore[method-assign]
     except (ImportError, AttributeError):
         pass
 
@@ -279,7 +279,7 @@ def patch_notebook() -> None:
             if sanitized:
                 old_stderr.write(sanitized)
 
-        ipython.showtraceback = _sanitized_showtraceback
+        ipython.showtraceback = _sanitized_showtraceback  # type: ignore[method-assign]
 
     _NOTEBOOK_PATCHED = True
 
@@ -295,25 +295,25 @@ def unpatch_notebook() -> None:
         return
 
     if _ORIGINAL_STDOUT_WRITE is not None:
-        sys.stdout.write = _ORIGINAL_STDOUT_WRITE
+        sys.stdout.write = _ORIGINAL_STDOUT_WRITE  # type: ignore[method-assign]
     if _ORIGINAL_STDERR_WRITE is not None:
-        sys.stderr.write = _ORIGINAL_STDERR_WRITE
+        sys.stderr.write = _ORIGINAL_STDERR_WRITE  # type: ignore[method-assign]
 
     try:
         from IPython import get_ipython
         ipython = get_ipython()
         if ipython is not None:
             if _ORIGINAL_WRITE_FORMAT_DATA is not None:
-                ipython.displayhook.write_format_data = _ORIGINAL_WRITE_FORMAT_DATA
+                ipython.displayhook.write_format_data = _ORIGINAL_WRITE_FORMAT_DATA  # type: ignore[method-assign]
             if _ORIGINAL_SHOWTRACEBACK is not None:
-                ipython.showtraceback = _ORIGINAL_SHOWTRACEBACK
+                ipython.showtraceback = _ORIGINAL_SHOWTRACEBACK  # type: ignore[method-assign]
     except ImportError:
         pass
 
     if _ORIGINAL_PUBLISH_DISPLAY_DATA is not None:
         try:
             import IPython.core.display_functions as _display_mod
-            _display_mod.publish_display_data = _ORIGINAL_PUBLISH_DISPLAY_DATA
+            _display_mod.publish_display_data = _ORIGINAL_PUBLISH_DISPLAY_DATA  # type: ignore[method-assign]
         except (ImportError, AttributeError):
             pass
 
@@ -372,7 +372,7 @@ def patch_logging() -> None:
         if _SENSITIVE_FILTER is not None:
             self.addFilter(_SENSITIVE_FILTER)
 
-    logging.Handler.__init__ = patched_handler_init
+    logging.Handler.__init__ = patched_handler_init  # type: ignore[method-assign]
 
     # Install a custom LogRecordFactory for pre-handler sanitization of msg/args
     _ORIGINAL_RECORD_FACTORY = logging.getLogRecordFactory()
@@ -387,7 +387,7 @@ def patch_logging() -> None:
         text = _ORIGINAL_FORMAT_EXCEPTION(self, ei)
         return sanitize_text(text, compiled)
 
-    logging.Formatter.formatException = sanitized_format_exception
+    logging.Formatter.formatException = sanitized_format_exception  # type: ignore[method-assign]
 
     _LOGGING_PATCHED = True
 
@@ -401,7 +401,7 @@ def unpatch_logging() -> None:
         return
 
     if _ORIGINAL_HANDLER_INIT is not None:
-        logging.Handler.__init__ = _ORIGINAL_HANDLER_INIT
+        logging.Handler.__init__ = _ORIGINAL_HANDLER_INIT  # type: ignore[method-assign]
 
     # Restore original LogRecordFactory
     if _ORIGINAL_RECORD_FACTORY is not None:
@@ -409,7 +409,7 @@ def unpatch_logging() -> None:
 
     # Restore original Formatter.formatException
     if _ORIGINAL_FORMAT_EXCEPTION is not None:
-        logging.Formatter.formatException = _ORIGINAL_FORMAT_EXCEPTION
+        logging.Formatter.formatException = _ORIGINAL_FORMAT_EXCEPTION  # type: ignore[method-assign]
 
     # Remove filter from existing handlers
     if _SENSITIVE_FILTER is not None:

--- a/freqtrade/loggers/sensitive_filter.py
+++ b/freqtrade/loggers/sensitive_filter.py
@@ -161,7 +161,7 @@ def sanitize_mime_bundle(data: dict[str, Any]) -> dict[str, Any]:
     Only string values are filtered; binary payloads (images) are left alone.
     """
     compiled = _get_default_compiled_patterns()
-    result = {}
+    result: dict[str, Any] = {}
     for mime_type, value in data.items():
         if isinstance(value, str):
             result[mime_type] = sanitize_text(value, compiled)
@@ -187,7 +187,7 @@ _ORIGINAL_PUBLISH_DISPLAY_DATA = None
 _ORIGINAL_SHOWTRACEBACK = None
 
 
-def patch_notebook() -> None:
+def patch_notebook() -> None:  # noqa: C901
     """Extend sensitive data filtering to all Jupyter/IPython output channels.
 
     Patches:
@@ -230,8 +230,8 @@ def patch_notebook() -> None:
             text = sanitize_text(text, compiled)
         return _ORIGINAL_STDERR_WRITE(text)
 
-    sys.stdout.write = _sanitized_stdout_write  # type: ignore[method-assign]
-    sys.stderr.write = _sanitized_stderr_write  # type: ignore[method-assign]
+    sys.stdout.write = _sanitized_stdout_write
+    sys.stderr.write = _sanitized_stderr_write
 
     # --- Channel 2: DisplayHook (last-expression auto-display) ---
     if hasattr(ipython, "displayhook") and hasattr(ipython.displayhook, "write_format_data"):
@@ -241,7 +241,7 @@ def patch_notebook() -> None:
             format_dict = sanitize_mime_bundle(format_dict)
             return _ORIGINAL_WRITE_FORMAT_DATA(format_dict, md_dict)
 
-        ipython.displayhook.write_format_data = _sanitized_write_format_data  # type: ignore[method-assign]
+        ipython.displayhook.write_format_data = _sanitized_write_format_data
 
     # --- Channel 3: publish_display_data (display() calls) ---
     try:
@@ -256,7 +256,7 @@ def patch_notebook() -> None:
                 data, metadata, transient=transient, **kwargs
             )
 
-        _display_mod.publish_display_data = _sanitized_publish_display_data  # type: ignore[method-assign]
+        _display_mod.publish_display_data = _sanitized_publish_display_data
     except (ImportError, AttributeError):
         pass
 
@@ -279,7 +279,7 @@ def patch_notebook() -> None:
             if sanitized:
                 old_stderr.write(sanitized)
 
-        ipython.showtraceback = _sanitized_showtraceback  # type: ignore[method-assign]
+        ipython.showtraceback = _sanitized_showtraceback
 
     _NOTEBOOK_PATCHED = True
 
@@ -295,25 +295,25 @@ def unpatch_notebook() -> None:
         return
 
     if _ORIGINAL_STDOUT_WRITE is not None:
-        sys.stdout.write = _ORIGINAL_STDOUT_WRITE  # type: ignore[method-assign]
+        sys.stdout.write = _ORIGINAL_STDOUT_WRITE
     if _ORIGINAL_STDERR_WRITE is not None:
-        sys.stderr.write = _ORIGINAL_STDERR_WRITE  # type: ignore[method-assign]
+        sys.stderr.write = _ORIGINAL_STDERR_WRITE
 
     try:
         from IPython import get_ipython
         ipython = get_ipython()
         if ipython is not None:
             if _ORIGINAL_WRITE_FORMAT_DATA is not None:
-                ipython.displayhook.write_format_data = _ORIGINAL_WRITE_FORMAT_DATA  # type: ignore[method-assign]
+                ipython.displayhook.write_format_data = _ORIGINAL_WRITE_FORMAT_DATA
             if _ORIGINAL_SHOWTRACEBACK is not None:
-                ipython.showtraceback = _ORIGINAL_SHOWTRACEBACK  # type: ignore[method-assign]
+                ipython.showtraceback = _ORIGINAL_SHOWTRACEBACK
     except ImportError:
         pass
 
     if _ORIGINAL_PUBLISH_DISPLAY_DATA is not None:
         try:
             import IPython.core.display_functions as _display_mod
-            _display_mod.publish_display_data = _ORIGINAL_PUBLISH_DISPLAY_DATA  # type: ignore[method-assign]
+            _display_mod.publish_display_data = _ORIGINAL_PUBLISH_DISPLAY_DATA
         except (ImportError, AttributeError):
             pass
 
@@ -409,7 +409,8 @@ def unpatch_logging() -> None:
 
     # Restore original Formatter.formatException
     if _ORIGINAL_FORMAT_EXCEPTION is not None:
-        logging.Formatter.formatException = _ORIGINAL_FORMAT_EXCEPTION  # type: ignore[method-assign]
+        fmt_cls = logging.Formatter
+        fmt_cls.formatException = _ORIGINAL_FORMAT_EXCEPTION  # type: ignore[method-assign]
 
     # Remove filter from existing handlers
     if _SENSITIVE_FILTER is not None:

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -1,4 +1,5 @@
 import logging
+import logging.handlers
 import re
 import sys
 
@@ -360,15 +361,18 @@ class TestSensitiveDataFilter:
     def test_filter_method_with_dict_args(self):
         """Test that dict-style args (for %(name)s formatting) are handled correctly."""
         f = SensitiveDataFilter()
+        # Set args after construction to avoid Python 3.12 LogRecord.__init__
+        # bug with single-key dict args (KeyError: 0 on args[0] check)
         record = logging.LogRecord(
             name="test",
             level=logging.INFO,
             pathname="",
             lineno=0,
             msg="Config: %(config)s",
-            args={"config": '{"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'},
+            args=None,
             exc_info=None,
         )
+        record.args = {"config": '{"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'}
         result = f.filter(record)
         assert result is True
         assert isinstance(record.args, dict)
@@ -621,6 +625,73 @@ class TestPatchLogging:
         assert is_logging_patched()
         unpatch_logging()
         assert not is_logging_patched()
+
+    def test_unpatch_restores_record_factory(self):
+        """unpatch_logging must restore the original LogRecordFactory."""
+        original = logging.getLogRecordFactory()
+        patch_logging()
+        # Factory should be different while patched
+        assert logging.getLogRecordFactory() is not original
+        unpatch_logging()
+        # Factory must be restored
+        assert logging.getLogRecordFactory() is original
+
+    def test_exc_text_sanitized_in_buffer(self):
+        """Exception text must be sanitized in the log record for RPC buffer safety."""
+        try:
+            patch_logging()
+            logger_test = logging.getLogger("test.exc_text_buffer")
+            logger_test.setLevel(logging.DEBUG)
+
+            # Create a handler that captures records (like FTBufferingHandler)
+            import io
+            handler = logging.handlers.MemoryHandler(capacity=100)
+            logger_test.addHandler(handler)
+
+            key = "0x" + "ef" * 32
+            try:
+                raise ValueError(f"Transaction failed with key {key}")
+            except ValueError:
+                logger_test.exception("Error occurred")
+
+            # Check the buffered record's exc_text
+            assert len(handler.buffer) > 0
+            record = handler.buffer[-1]
+            # Force exc_text generation if not yet set
+            if record.exc_text is None:
+                formatter = logging.Formatter()
+                formatter.format(record)
+            assert key not in (record.exc_text or ""), \
+                f"Raw key leaked in exc_text: {record.exc_text}"
+
+            logger_test.removeHandler(handler)
+        finally:
+            unpatch_logging()
+
+    def test_dict_args_with_named_format_preserved(self):
+        """Dict args for %(name)s formatting must stay as dicts, not become tuples."""
+        try:
+            patch_logging()
+            # Construct record with args=None, then set args after to avoid
+            # Python 3.12 LogRecord.__init__ bug with single-key dict args
+            record = logging.LogRecord(
+                name="test",
+                level=logging.INFO,
+                pathname="",
+                lineno=0,
+                msg="Config: %(config)s",
+                args=None,
+                exc_info=None,
+            )
+            record.args = {"config": "some_value"}
+            # The record should still format correctly
+            formatter = logging.Formatter("%(message)s")
+            message = formatter.format(record)
+            assert "some_value" in message
+            # Args must still be a dict
+            assert isinstance(record.args, dict)
+        finally:
+            unpatch_logging()
 
 
 class TestPatchNotebook:

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -16,7 +16,6 @@ from freqtrade.loggers.sensitive_filter import (
     SensitiveDataFilter,
     contains_secret,
     is_logging_patched,
-    is_notebook_patched,
     patch_logging,
     patch_notebook,
     sanitize_text,

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -11,7 +11,17 @@ from freqtrade.loggers import (
     setup_logging,
     setup_logging_pre,
 )
-from freqtrade.loggers.sensitive_filter import SensitiveDataFilter
+from freqtrade.loggers.sensitive_filter import (
+    SensitiveDataFilter,
+    contains_secret,
+    is_logging_patched,
+    is_notebook_patched,
+    patch_logging,
+    patch_notebook,
+    sanitize_text,
+    unpatch_logging,
+    unpatch_notebook,
+)
 from freqtrade.loggers.set_log_levels import (
     reduce_verbosity_for_bias_tester,
     restore_verbosity_for_bias_tester,
@@ -464,3 +474,176 @@ class TestSensitiveDataFilter:
         result = f._sanitize(text)
         assert "0x742d35cc6634c0532925a3b844bc454e4438f44e" not in result
         assert "[REDACTED]" in result
+
+
+class TestSanitizeTextHelpers:
+    """Tests for the module-level sanitize_text, contains_secret, etc."""
+
+    def test_sanitize_text_bare_hex_key(self):
+        """Bare 0x + 64 hex chars are redacted even without a key name."""
+        key = "0x" + "ab" * 32  # 64 hex chars
+        result = sanitize_text(f"Using key {key} for signing")
+        assert key not in result
+        assert "[REDACTED-KEY]" in result
+
+    def test_sanitize_text_preserves_short_hex(self):
+        """Short hex strings (tx hashes, addresses) are NOT redacted by bare key pattern."""
+        tx_hash = "0x" + "ab" * 16  # Only 32 hex chars
+        result = sanitize_text(f"TX: {tx_hash}")
+        assert tx_hash in result  # Should NOT be redacted
+
+    def test_sanitize_text_pem_key(self):
+        """PEM private key blocks are redacted."""
+        pem = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBg...\n-----END PRIVATE KEY-----"
+        result = sanitize_text(f"Key: {pem}")
+        assert "MIIEvQIBADANBg" not in result
+        assert "[REDACTED-PEM-KEY]" in result
+
+    def test_sanitize_text_ed25519_secret(self):
+        """ed25519 secret format is redacted."""
+        secret = "ed25519:JC5mjh84GkitnPrzvJLeN8AJ8CGZeKNfrvZmLJ9cBC6w"
+        result = sanitize_text(f"Secret: {secret}")
+        assert "JC5mjh84Gki" not in result
+        assert "[REDACTED-ED25519]" in result
+
+    def test_contains_secret_positive(self):
+        """contains_secret returns True for bare hex keys."""
+        key = "0x" + "ab" * 32
+        assert contains_secret(f"key={key}") is True
+
+    def test_contains_secret_negative(self):
+        """contains_secret returns False for normal text."""
+        assert contains_secret("Hello world, price is $100.50") is False
+
+    def test_contains_secret_pem(self):
+        """contains_secret detects PEM blocks."""
+        pem = "-----BEGIN PRIVATE KEY-----\ndata\n-----END PRIVATE KEY-----"
+        assert contains_secret(pem) is True
+
+    def test_contains_secret_keyed_pattern(self):
+        """contains_secret detects keyed patterns like apiKey."""
+        text = "{'apiKey': 'my-super-secret-api-key-12345'}"
+        assert contains_secret(text) is True
+
+    def test_sanitize_text_exc_text_redacted(self):
+        """Exception text on LogRecord is also sanitized."""
+        f = SensitiveDataFilter()
+        record = logging.LogRecord(
+            name="test", level=logging.INFO, pathname="", lineno=0,
+            msg="error", args=(), exc_info=None,
+        )
+        key = "0x" + "ab" * 32
+        record.exc_text = f"Traceback: privateKey={key}"
+        f.filter(record)
+        assert key not in record.exc_text
+        assert "[REDACTED" in record.exc_text
+
+
+class TestConfigValidationPrivateKeys:
+    """Tests for _validate_no_raw_private_keys."""
+
+    def test_rejects_raw_private_key_top_level(self):
+        """Raw private_key at exchange level is rejected."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+        from freqtrade.exceptions import ConfigurationError
+
+        conf = {"exchange": {"name": "gmx", "private_key": "0x" + "ab" * 32}}
+        with pytest.raises(ConfigurationError, match="Raw private key found"):
+            _validate_no_raw_private_keys(conf)
+
+    def test_rejects_raw_privateKey_top_level(self):
+        """Raw privateKey (camelCase) at exchange level is rejected."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+        from freqtrade.exceptions import ConfigurationError
+
+        conf = {"exchange": {"name": "gmx", "privateKey": "0x" + "ab" * 32}}
+        with pytest.raises(ConfigurationError, match="Raw private key found"):
+            _validate_no_raw_private_keys(conf)
+
+    def test_rejects_raw_key_in_ccxt_config(self):
+        """Raw privateKey inside ccxt_config is rejected."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+        from freqtrade.exceptions import ConfigurationError
+
+        conf = {
+            "exchange": {
+                "name": "gmx",
+                "ccxt_config": {"privateKey": "0x" + "ab" * 32},
+            }
+        }
+        with pytest.raises(ConfigurationError, match="ccxt_config"):
+            _validate_no_raw_private_keys(conf)
+
+    def test_rejects_raw_key_in_ccxt_sync_config(self):
+        """Raw privateKey inside ccxt_sync_config is rejected."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+        from freqtrade.exceptions import ConfigurationError
+
+        conf = {
+            "exchange": {
+                "name": "gmx",
+                "ccxt_sync_config": {"privateKey": "0x" + "ab" * 32},
+            }
+        }
+        with pytest.raises(ConfigurationError, match="ccxt_sync_config"):
+            _validate_no_raw_private_keys(conf)
+
+    def test_accepts_private_key_env(self):
+        """private_key_env is accepted (no error raised)."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+
+        conf = {"exchange": {"name": "gmx", "private_key_env": "GMX_PRIVATE_KEY"}}
+        _validate_no_raw_private_keys(conf)  # Should not raise
+
+    def test_accepts_no_private_key(self):
+        """Config without any private key field is accepted."""
+        from freqtrade.configuration.config_validation import _validate_no_raw_private_keys
+
+        conf = {"exchange": {"name": "binance", "key": "abc", "secret": "def"}}
+        _validate_no_raw_private_keys(conf)  # Should not raise
+
+
+class TestPatchLogging:
+    """Tests for patch_logging / unpatch_logging."""
+
+    def test_patch_logging_idempotent(self):
+        """Calling patch_logging multiple times is safe."""
+        try:
+            patch_logging()
+            patch_logging()  # Second call should be no-op
+            assert is_logging_patched()
+        finally:
+            unpatch_logging()
+
+    def test_unpatch_restores_state(self):
+        """unpatch_logging restores original state."""
+        patch_logging()
+        assert is_logging_patched()
+        unpatch_logging()
+        assert not is_logging_patched()
+
+
+class TestPatchNotebook:
+    """Tests for notebook patching (stdout/stderr channels)."""
+
+    def test_patch_notebook_noop_without_ipython(self):
+        """patch_notebook is a no-op when IPython is not running."""
+        patch_notebook()
+        # Should not raise, and should not be marked as patched
+        # (unless we're actually in IPython, which we're not in pytest)
+        # Just verify it doesn't crash
+        unpatch_notebook()
+
+    def test_patch_notebook_idempotent(self):
+        """Calling patch_notebook multiple times is safe."""
+        patch_notebook()
+        patch_notebook()
+        unpatch_notebook()
+
+    def test_sanitize_text_through_stdout_mock(self):
+        """Verify sanitize_text works on stdout-like content."""
+        key = "0x" + "cd" * 32
+        output = f"Debug: wallet key is {key}"
+        sanitized = sanitize_text(output)
+        assert key not in sanitized
+        assert "[REDACTED-KEY]" in sanitized


### PR DESCRIPTION
## Summary

Security hardening after a private key leak via a Jupyter notebook committed to git. Full context: https://github.com/tradingstrategy-ai/freqtrade-strategies/issues/157

**Related PRs:**
- freqtrade-strategies: https://github.com/tradingstrategy-ai/freqtrade-strategies/pull/158
- web3-ethereum-defi: https://github.com/tradingstrategy-ai/web3-ethereum-defi/pull/909
- nautilus-strategies: https://github.com/tradingstrategy-ai/nautilus-strategies/pull/24

### Changes

**Config validation:**
- `_validate_no_raw_private_keys()` — rejects raw `private_key`/`privateKey` in exchange config and all `ccxt_config` sections before any other code can echo the value
- New `private_key_env` config schema field — keys referenced by env var name, never stored in files
- `_resolve_private_key()` in `exchange.py` — resolves from env var at runtime, never writes back to config

**Expanded SensitiveDataFilter:**
- Bare `0x` + 64 hex char private keys (not just keyed dict patterns)
- PEM private key blocks
- ed25519 secret format
- Public helpers: `sanitize_text()`, `contains_secret()`, `sanitize_mime_bundle()`

**Log sanitization (closes RPC buffer blind spot):**
- `LogRecordFactory` — sanitizes `msg` and `args` at record creation, before any handler sees them
- `Formatter.formatException` patch — sanitizes tracebacks at generation time, so `exc_text` is clean when read by `_rpc_get_logs()` from `bufferHandler.buffer`
- `unpatch_logging()` fully restores all three: `LogRecordFactory`, `Formatter.formatException`, `Handler.__init__`

**Notebook output filtering:**
- `patch_notebook()` — covers `sys.stdout.write`, `sys.stderr.write`, IPython `DisplayHook`, `publish_display_data`, and `showtraceback`
- Idempotent, no-op outside IPython
- `setup_logging()` in `loggers/__init__.py` now calls `patch_logging()` (with LogRecordFactory) instead of manual per-handler filter addition

## Test plan

- [x] 48 tests pass, 1 skipped (`pytest tests/test_log_setup.py -v`)
- [x] `unpatch_logging()` restores original `LogRecordFactory`
- [x] `logger.exception()` with private key → `[REDACTED-KEY]` in `bufferHandler.buffer[-1].exc_text`
- [x] `%(name)s` dict args preserved (no `KeyError: 0`)
- [x] Bare hex key, PEM, ed25519 all detected and redacted
- [x] Config validation rejects raw keys in exchange, ccxt_config, ccxt_sync_config, ccxt_async_config


🤖 Generated with [Claude Code](https://claude.com/claude-code)