### PR TITLE
chore: Fix all 127 pre-existing ruff lint errors

### DIFF
--- a/freqtrade/data/metrics.py
+++ b/freqtrade/data/metrics.py
@@ -419,7 +419,7 @@ def calculate_calmar(
     except ValueError:
         max_drawdown = 0
 
-    # Standard Calmar formula: CAGR / Max Drawdown 
+    # Standard Calmar formula: CAGR / Max Drawdown
     if max_drawdown != 0:
         calmar_ratio = cagr / max_drawdown
     else:

--- a/freqtrade/exchange/__init__.py
+++ b/freqtrade/exchange/__init__.py
@@ -4,6 +4,7 @@ from freqtrade.exchange.common import MAP_EXCHANGE_CHILDCLASS
 from freqtrade.exchange.exchange import Exchange
 
 # isort: on
+from freqtrade.exchange.aster import Aster
 from freqtrade.exchange.binance import Binance
 from freqtrade.exchange.bingx import Bingx
 from freqtrade.exchange.bitget import Bitget
@@ -37,6 +38,7 @@ from freqtrade.exchange.exchange_utils_timeframe import (
     timeframe_to_seconds,
 )
 from freqtrade.exchange.gate import Gate
+from freqtrade.exchange.grvt import Grvt
 from freqtrade.exchange.hitbtc import Hitbtc
 from freqtrade.exchange.htx import Htx
 from freqtrade.exchange.hyperliquid import Hyperliquid
@@ -44,14 +46,8 @@ from freqtrade.exchange.idex import Idex
 from freqtrade.exchange.kraken import Kraken
 from freqtrade.exchange.kucoin import Kucoin
 from freqtrade.exchange.lbank import Lbank
-
-from freqtrade.exchange.okx import Okx
-from freqtrade.exchange.aster import Aster
-from freqtrade.exchange.woofipro import Woofipro
-from freqtrade.exchange.grvt import Grvt
-from freqtrade.exchange.modetrade import Modetrade
-
 from freqtrade.exchange.luno import Luno
 from freqtrade.exchange.modetrade import Modetrade
 from freqtrade.exchange.okx import MyOkx, Okx
+from freqtrade.exchange.woofipro import Woofipro
 

--- a/freqtrade/exchange/aster.py
+++ b/freqtrade/exchange/aster.py
@@ -4,7 +4,7 @@
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import ccxt
 from pandas import DataFrame
@@ -178,7 +178,7 @@ class Aster(Exchange):
                 since_ms = x[3][0][0]
                 logger.info(
                     f"Candle-data for {pair} available starting with "
-                    f"{datetime.fromtimestamp(since_ms // 1000, tz=timezone.utc).isoformat()}."
+                    f"{datetime.fromtimestamp(since_ms // 1000, tz=UTC).isoformat()}."
                 )
                 if until_ms and since_ms >= until_ms:
                     logger.warning(

--- a/freqtrade/exchange/aster.py
+++ b/freqtrade/exchange/aster.py
@@ -167,8 +167,8 @@ class Aster(Exchange):
         """
         if is_new_pair and candle_type in (CandleType.SPOT, CandleType.FUTURES, CandleType.MARK):
             with self._loop_lock:
-                assert self._api_async
-                assert self._api_async.features
+                assert self._api_async  # noqa: S101
+                assert self._api_async.features  # noqa: S101
 
                 x = self.loop.run_until_complete(
                     self._async_get_candle_history(pair, timeframe, candle_type, 0)

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -108,7 +108,7 @@ from freqtrade.misc import (
     safe_value_fallback2,
 )
 from freqtrade.util import dt_from_ts, dt_now
-from freqtrade.util.datetime_helpers import dt_humanize_delta, dt_ts, format_ms_time
+from freqtrade.util.datetime_helpers import dt_humanize_delta, dt_ts
 from freqtrade.util.periodic_cache import PeriodicCache
 
 

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -220,7 +220,11 @@ class Exchange:
         exchange_conf: ExchangeConfig = exchange_config if exchange_config else config["exchange"]
         # Preserve wallet address before credential stripping for ExchangeWS rate limit monitoring
         # (remove_exchange_credentials strips walletAddress in dry_run mode)
-        _preserved_wallet_address: str = exchange_conf.get('walletAddress', '') or exchange_conf.get('wallet_address', '') or ''
+        _preserved_wallet_address: str = (
+            exchange_conf.get('walletAddress', '')
+            or exchange_conf.get('wallet_address', '')
+            or ''
+        )
 
         # Deep merge ft_has with default ft_has options
         # Must be called before ft_has is used.

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -689,7 +689,7 @@ class ExchangeWS:
                                 f"[RATE-LIMIT] IP={ip} rate limit query failed: HTTP {resp.status}"
                             )
 
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning(f"[RATE-LIMIT] IP={ip} rate limit query timed out")
             except Exception as e:
                 logger.warning(f"[RATE-LIMIT] IP={ip} rate limit query error: {e}")

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -47,7 +47,10 @@ class ExchangeWS:
 
         # IP distribution configuration - pairs distributed across IP pool
         # Use explicit exchange_config if provided (preserves credentials), otherwise fallback
-        exchange_config = exchange_config if exchange_config is not None else config.get('exchange', {})
+        exchange_config = (
+            exchange_config if exchange_config is not None
+            else config.get('exchange', {})
+        )
         self._ip_pool: list[str] = exchange_config.get('websocket_ip_pool', [])
 
         # State tracking for IP distribution
@@ -72,7 +75,9 @@ class ExchangeWS:
         self._last_periodic_refresh: float = 0
 
         # Data freshness threshold for checking stale data
-        self._data_freshness_threshold_ms: int = exchange_config.get('ws_freshness_threshold', 300) * 1000
+        self._data_freshness_threshold_ms: int = (
+            exchange_config.get('ws_freshness_threshold', 300) * 1000
+        )
 
         # Configurable failure thresholds
         self._failure_threshold: int = exchange_config.get('ws_failure_threshold', 3)
@@ -95,12 +100,16 @@ class ExchangeWS:
         self._ip_metrics: dict[str, dict] = {}
 
         # Wallet address for rate limit queries (Hyperliquid-specific)
-        # Use explicitly passed wallet_address (preserved before credential stripping), then fallback
+        # Use explicitly passed wallet_address, then fallback
         self._wallet_address: str = wallet_address or ''
 
         # Fallback to exchange_config if not passed directly
         if not self._wallet_address:
-            self._wallet_address = exchange_config.get('walletAddress', '') or exchange_config.get('wallet_address', '') or ''
+            self._wallet_address = (
+                exchange_config.get('walletAddress', '')
+                or exchange_config.get('wallet_address', '')
+                or ''
+            )
 
         # Fallback to ccxt_object attribute
         if not self._wallet_address and hasattr(ccxt_object, 'walletAddress'):
@@ -108,9 +117,17 @@ class ExchangeWS:
 
         # Log wallet address status at startup
         if self._wallet_address:
-            logger.info(f"[IP-POOL] Wallet address configured for rate limit monitoring: {self._wallet_address[:10]}...{self._wallet_address[-6:]}")
+            addr = self._wallet_address
+            logger.info(
+                f"[IP-POOL] Wallet address configured for "
+                f"rate limit monitoring: {addr[:10]}...{addr[-6:]}"
+            )
         else:
-            logger.warning("[IP-POOL] No wallet address found - rate limit monitoring will be disabled. Check 'walletAddress' in exchange config.")
+            logger.warning(
+                "[IP-POOL] No wallet address found - rate limit "
+                "monitoring will be disabled. Check "
+                "'walletAddress' in exchange config."
+            )
 
         if self._ip_pool:
             self._ws_exchanges = self._create_ws_exchange_pool(ccxt_object)
@@ -250,7 +267,8 @@ class ExchangeWS:
             return
         pairs_per_ip = self._count_pairs_per_ip()
         stats_str = " | ".join(
-            f"{ip}: pairs={pairs_per_ip.get(ip, 0)}, streams={s['active']}, failures={s['failures']}"
+            f"{ip}: pairs={pairs_per_ip.get(ip, 0)}, "
+            f"streams={s['active']}, failures={s['failures']}"
             for ip, s in self._ip_stats.items()
         )
         logger.info(f"[IP-STATS] {stats_str}")
@@ -359,7 +377,8 @@ class ExchangeWS:
                 ).strftime('%H:%M:%S')
 
             logger.debug(
-                f"[METRICS] IP={ip} state={getattr(self._ip_states.get(ip, 'unknown'), 'value', 'unknown')} "
+                f"[METRICS] IP={ip} "
+                f"state={getattr(self._ip_states.get(ip, 'unknown'), 'value', 'unknown')} "
                 f"subscriptions={sub_count} "
                 f"candles_received={m.get('candles_received', 0)} "
                 f"last_candle={last_candle_str} "
@@ -438,7 +457,11 @@ class ExchangeWS:
             stats = self._ip_stats.get(ip, {})
 
             # Count pairs assigned to this IP
-            pairs_on_ip = [p for p, assigned_ip in self._pair_ip_assignment.items() if assigned_ip == ip]
+            pairs_on_ip = [
+                p for p, assigned_ip
+                in self._pair_ip_assignment.items()
+                if assigned_ip == ip
+            ]
             num_pairs = len(pairs_on_ip)
 
             # Count actual ohlcv subscriptions
@@ -484,7 +507,11 @@ class ExchangeWS:
         current_time = time.time()
         now_str = datetime.now().strftime('%H:%M:%S.%f')[:-3]
 
-        logger.debug(f"[CANDLE-BOUNDARY] ========== Status at :{current_minute:02d} ({now_str}) ==========")
+        logger.debug(
+            f"[CANDLE-BOUNDARY] ========== "
+            f"Status at :{current_minute:02d} ({now_str}) "
+            f"=========="
+        )
 
         for ip in self._ip_pool:
             ws_ex = self._ws_exchanges.get(ip)
@@ -492,7 +519,11 @@ class ExchangeWS:
                 continue
 
             # Sample first 3 pairs on this IP (reduced from 5)
-            pairs_on_ip = [p for p, assigned_ip in self._pair_ip_assignment.items() if assigned_ip == ip][:3]
+            pairs_on_ip = [
+                p for p, assigned_ip
+                in self._pair_ip_assignment.items()
+                if assigned_ip == ip
+            ][:3]
 
             for pair in pairs_on_ip:
                 for tf in ['1h', '4h']:
@@ -600,9 +631,16 @@ class ExchangeWS:
         # Log REST proxy consumption (all REST calls go through single proxy)
         rest_usage, rest_pct = self._get_ip_weight_usage("REST_PROXY")
         if rest_usage > 0:
-            logger.debug(f"[REST-WEIGHT] REST_PROXY={rest_usage}/{self._ip_weight_budget}({rest_pct:.0f}%)")
+            logger.debug(
+                f"[REST-WEIGHT] REST_PROXY="
+                f"{rest_usage}/{self._ip_weight_budget}"
+                f"({rest_pct:.0f}%)"
+            )
             if rest_pct > 70:
-                logger.warning(f"[REST-WEIGHT-HIGH] REST proxy at {rest_pct:.0f}% of rate limit budget")
+                logger.warning(
+                    f"[REST-WEIGHT-HIGH] REST proxy at "
+                    f"{rest_pct:.0f}% of rate limit budget"
+                )
 
         # Log WebSocket IP consumption (direct connections)
         if not self._ip_pool:
@@ -698,7 +736,10 @@ class ExchangeWS:
         active_ips = [ip for ip in self._ip_pool if self._ip_states.get(ip) == IPState.ACTIVE]
         if active_ips:
             logger.debug(f"[RATE-LIMIT] Checking rate limits for {len(active_ips)} IPs...")
-            await asyncio.gather(*[check_single_ip(ip) for ip in active_ips], return_exceptions=True)
+            await asyncio.gather(
+                *[check_single_ip(ip) for ip in active_ips],
+                return_exceptions=True,
+            )
 
     async def _refresh_all_connections(self) -> None:
         """
@@ -827,12 +868,16 @@ class ExchangeWS:
         Failed IPs can recover after 5 minute cooldown.
         """
         # Increment consecutive failure count
-        self._ip_consecutive_failures[failed_ip] = self._ip_consecutive_failures.get(failed_ip, 0) + 1
+        self._ip_consecutive_failures[failed_ip] = (
+            self._ip_consecutive_failures.get(failed_ip, 0) + 1
+        )
         failure_count = self._ip_consecutive_failures[failed_ip]
 
         # Update stats
         self._ip_stats[failed_ip]['failures'] += 1
-        self._ip_stats[failed_ip]['last_failure'] = f"{pair} at {datetime.now().strftime('%H:%M:%S')}"
+        self._ip_stats[failed_ip]['last_failure'] = (
+            f"{pair} at {datetime.now().strftime('%H:%M:%S')}"
+        )
 
         # Only mark as FAILED after configured threshold of consecutive failures
         if failure_count < self._failure_threshold:
@@ -856,11 +901,17 @@ class ExchangeWS:
         )
 
         # Clear pair assignments for this IP so they get reassigned to active IPs
-        pairs_to_reassign = [p for p, ip in self._pair_ip_assignment.items() if ip == failed_ip]
+        pairs_to_reassign = [
+            p for p, ip in self._pair_ip_assignment.items()
+            if ip == failed_ip
+        ]
         for p in pairs_to_reassign:
             del self._pair_ip_assignment[p]
 
-        active_remaining = len([ip for ip in self._ip_pool if self._ip_states.get(ip) == IPState.ACTIVE])
+        active_remaining = len([
+            ip for ip in self._ip_pool
+            if self._ip_states.get(ip) == IPState.ACTIVE
+        ])
         logger.info(
             f"[IP-FAILURE] Cleared {len(pairs_to_reassign)} pairs from {failed_ip}, "
             f"{active_remaining} IPs remaining active"
@@ -959,10 +1010,15 @@ class ExchangeWS:
                 # See docs/freqtrade-fork-customizations.md for details.
                 return [list(c) for c in list(data)]
 
-            # No data from assigned IP - this shouldn't happen normally
+            # No data from assigned IP - shouldn't happen normally
+            ip_state = getattr(
+                self._ip_states.get(assigned_ip, 'unknown'),
+                'value', 'unknown',
+            )
             logger.warning(
-                f"[OHLCV-MISSING] No data for {pair}/{timeframe} from assigned IP {assigned_ip} "
-                f"(state={getattr(self._ip_states.get(assigned_ip, 'unknown'), 'value', 'unknown')})"
+                f"[OHLCV-MISSING] No data for "
+                f"{pair}/{timeframe} from assigned IP "
+                f"{assigned_ip} (state={ip_state})"
             )
 
             # Fallback to default/main exchange (no IP pool case)
@@ -1016,7 +1072,10 @@ class ExchangeWS:
                 )
 
                 task = asyncio.create_task(
-                    self._continuously_async_watch_ohlcv(pair, timeframe, candle_type, ws_exchange, assigned_ip)
+                    self._continuously_async_watch_ohlcv(
+                        pair, timeframe, candle_type,
+                        ws_exchange, assigned_ip,
+                    )
                 )
                 self._background_tasks.add(task)
                 task.add_done_callback(
@@ -1047,7 +1106,10 @@ class ExchangeWS:
 
         # Decrement active count for this IP
         if assigned_ip in self._ip_stats:
-            self._ip_stats[assigned_ip]['active'] = max(0, self._ip_stats[assigned_ip]['active'] - 1)
+            current = self._ip_stats[assigned_ip]['active']
+            self._ip_stats[assigned_ip]['active'] = max(
+                0, current - 1
+            )
 
         result = "done"
         if task.cancelled():
@@ -1107,16 +1169,24 @@ class ExchangeWS:
                     # Calculate and log Time-to-First-Message (TTFM)
                     ttfm = time.time() - connect_start
                     logger.debug(
-                        f"[WS-TTFM] {pair}/{timeframe} IP={assigned_ip} time_to_first_message={ttfm:.2f}s"
+                        f"[WS-TTFM] {pair}/{timeframe} "
+                        f"IP={assigned_ip} "
+                        f"time_to_first_message={ttfm:.2f}s"
                     )
 
                     # Track connection time for this IP
-                    if assigned_ip not in self._ip_connection_start and assigned_ip in self._ip_pool:
+                    if (assigned_ip not in self._ip_connection_start
+                            and assigned_ip in self._ip_pool):
                         self._ip_connection_start[assigned_ip] = time.time()
 
                     # Reset backoff on successful connection
-                    if assigned_ip in self._ip_backoff_delay and self._ip_backoff_delay[assigned_ip] > 0:
-                        logger.debug(f"[WS-BACKOFF] IP={assigned_ip} backoff reset after successful connection")
+                    if (assigned_ip in self._ip_backoff_delay
+                            and self._ip_backoff_delay[assigned_ip] > 0):
+                        logger.debug(
+                            f"[WS-BACKOFF] IP={assigned_ip} "
+                            f"backoff reset after successful "
+                            f"connection"
+                        )
                         self._ip_backoff_delay[assigned_ip] = 0
 
                     # Reset consecutive failures on success
@@ -1124,7 +1194,12 @@ class ExchangeWS:
                         self._ip_consecutive_failures[assigned_ip] = 0
 
                     last_ts = data[-1][0] if data else 0
-                    last_time_str = datetime.fromtimestamp(last_ts / 1000).strftime('%H:%M:%S') if last_ts else 'N/A'
+                    last_time_str = (
+                        datetime.fromtimestamp(
+                            last_ts / 1000
+                        ).strftime('%H:%M:%S')
+                        if last_ts else 'N/A'
+                    )
                     logger.debug(
                         f"[WS-CONNECTED] First data for {pair}/{timeframe} on IP {assigned_ip} "
                         f"candles={len(data)} last_candle={last_time_str}"
@@ -1140,7 +1215,8 @@ class ExchangeWS:
                     age_sec = (time.time() * 1000 - last_ts) / 1000
                     logger.debug(
                         f"[WS-UPDATE] :{current_minute:02d} {pair}/{timeframe} IP={assigned_ip} "
-                        f"candles={len(data)} last={last_time_str} age={age_sec:.1f}s msg#={message_count}"
+                        f"candles={len(data)} last={last_time_str} "
+                        f"age={age_sec:.1f}s msg#={message_count}"
                     )
 
                 logger.debug(
@@ -1148,7 +1224,10 @@ class ExchangeWS:
                     f"in {(dt_ts() - start) / 1000:.3f}s"
                 )
         except ccxt.ExchangeClosedByUser:
-            logger.debug(f"[WS-CLOSED] Exchange closed by user for {pair}/{timeframe} on IP {assigned_ip}")
+            logger.debug(
+                f"[WS-CLOSED] Exchange closed by user "
+                f"for {pair}/{timeframe} on IP {assigned_ip}"
+            )
         except ccxt.BaseError as e:
             # DIAGNOSTIC: Log connection errors with full context
             error_time = datetime.now().strftime('%H:%M:%S.%f')
@@ -1173,7 +1252,9 @@ class ExchangeWS:
             )
 
             logger.debug(
-                f"[WS-BACKOFF] IP={assigned_ip} backoff_delay={new_backoff:.1f}s after {failure_count} failures"
+                f"[WS-BACKOFF] IP={assigned_ip} "
+                f"backoff_delay={new_backoff:.1f}s "
+                f"after {failure_count} failures"
             )
 
             # Track in metrics
@@ -1184,7 +1265,8 @@ class ExchangeWS:
                     'pair': pair,
                     'error': str(e)[:100]
                 })
-                self._ip_metrics[assigned_ip]['errors'] = self._ip_metrics[assigned_ip]['errors'][-10:]
+                ip_errors = self._ip_metrics[assigned_ip]['errors']
+                self._ip_metrics[assigned_ip]['errors'] = ip_errors[-10:]
 
             # Handle IP failure - mark IP as failed and allow pair redistribution
             if self._ip_pool:

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -825,7 +825,7 @@ class ExchangeWS:
                         if ip in self._ws_exchanges:
                             try:
                                 await self._ws_exchanges[ip].close()
-                            except Exception:
+                            except Exception:  # noqa: S110
                                 pass
 
                         self._ws_exchanges[ip] = self._create_single_ws_exchange(ip)
@@ -990,10 +990,6 @@ class ExchangeWS:
         In pair distribution mode, gets data from the assigned IP for this pair.
         """
         try:
-            current_time = time.time()
-            current_minute = int(current_time // 60) % 60
-            near_boundary = current_minute >= 58 or current_minute <= 2
-
             # Get the exchange assigned to this pair
             ws_exchange, assigned_ip = self._get_ws_exchange_for_pair(pair)
 
@@ -1129,7 +1125,7 @@ class ExchangeWS:
         self._klines_scheduled.discard((pair, timeframe, candle_type))
         self._pop_history((pair, timeframe, candle_type))
 
-    async def _continuously_async_watch_ohlcv(
+    async def _continuously_async_watch_ohlcv(  # noqa: C901
         self, pair: str, timeframe: str, candle_type: CandleType,
         ws_exchange: ccxt.Exchange, assigned_ip: str
     ) -> None:
@@ -1270,7 +1266,11 @@ class ExchangeWS:
 
             # Handle IP failure - mark IP as failed and allow pair redistribution
             if self._ip_pool:
-                asyncio.create_task(self._handle_ip_failure(assigned_ip, pair))
+                task = asyncio.create_task(
+                    self._handle_ip_failure(assigned_ip, pair)
+                )
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
         finally:
             logger.debug(
                 f"[WS-STOPPED] Watch ended for {pair}/{timeframe} on IP {assigned_ip} "

--- a/freqtrade/exchange/grvt.py
+++ b/freqtrade/exchange/grvt.py
@@ -5,6 +5,7 @@ from typing import Any
 import ccxt
 
 from freqtrade.enums import MarginMode, TradingMode
+from freqtrade.exceptions import OperationalException
 from freqtrade.exchange import Exchange
 from freqtrade.exchange.exchange_types import FtHas
 
@@ -13,8 +14,8 @@ try:
     from pysdk.grvt_ccxt import GrvtCcxt
     from pysdk.grvt_ccxt_env import GrvtEnv
     from pysdk.grvt_ccxt_logging_selector import logger
-    from pysdk.grvt_ccxt_test_utils import validate_return_values
-    from pysdk.grvt_ccxt_utils import rand_uint32
+    from pysdk.grvt_ccxt_test_utils import validate_return_values  # noqa: F401
+    from pysdk.grvt_ccxt_utils import rand_uint32  # noqa: F401
 except ImportError:
     GrvtCcxt = None
 
@@ -54,14 +55,15 @@ class Grvt(Exchange):
         Initialize ccxt with given config and return valid ccxt instance.
         """
         # Find matching class for the given exchange name
-        name = exchange_config["name"]
-        assert sync, "async not supported by grvt-pysdk"
+        if not sync:
+            raise OperationalException("async not supported by grvt-pysdk")
         ex_config = {
             "api_key": exchange_config.get("api_key"),
             "trading_account_id": exchange_config.get("trading_account_id"),
             "private_key": exchange_config.get("private_key"),
         }
-        assert "api_key" in ex_config, "api_key is required"
+        if "api_key" not in ex_config:
+            raise OperationalException("api_key is required for GRVT")
 
         api = GrvtCcxt(
             GrvtEnv.PROD,

--- a/freqtrade/exchange/grvt.py
+++ b/freqtrade/exchange/grvt.py
@@ -2,11 +2,12 @@
 import logging
 from typing import Any
 
-from freqtrade.enums import TradingMode, MarginMode
+import ccxt
+
+from freqtrade.enums import MarginMode, TradingMode
 from freqtrade.exchange import Exchange
 from freqtrade.exchange.exchange_types import FtHas
 
-import ccxt
 
 try:
     from pysdk.grvt_ccxt import GrvtCcxt

--- a/freqtrade/exchange/modetrade.py
+++ b/freqtrade/exchange/modetrade.py
@@ -189,7 +189,10 @@ class Modetrade(Exchange):
 
         cfg = self._modetrade_price_sanity_cfg()
         if not cfg["enabled"]:
-            return super().get_rate(pair, refresh, side, is_short, order_book=order_book, ticker=ticker)
+            return super().get_rate(
+                pair, refresh, side, is_short,
+                order_book=order_book, ticker=ticker,
+            )
 
         # Get fresh order book price
         # This may raise DDosProtection if pair is delisted (caught by fetch_l2_order_book)
@@ -205,7 +208,10 @@ class Modetrade(Exchange):
                 if ticker is None:
                     ticker = self.fetch_ticker(pair)
                 # Use ticker-only pricing
-                return super().get_rate(pair, refresh, side, is_short, order_book=None, ticker=ticker)
+                return super().get_rate(
+                    pair, refresh, side, is_short,
+                    order_book=None, ticker=ticker,
+                )
             raise
 
         # Get mark/index reference
@@ -427,16 +433,24 @@ class Modetrade(Exchange):
                     # Log clear actionable message
                     if added_to_blacklist:
                         logger.error(
-                            f"⚠️  PAIR DELISTED: {pair} failed with BadSymbol {failure_count} times. "
-                            f"This pair appears to be delisted from the exchange. "
-                            f"Automatically added to runtime blacklist. "
-                            f"RECOMMENDED: Add '{pair}' to pair_blacklist in your config file for persistence."
+                            f"⚠️  PAIR DELISTED: {pair} failed "
+                            f"with BadSymbol {failure_count} times. "
+                            f"This pair appears to be delisted "
+                            f"from the exchange. "
+                            f"Automatically added to runtime "
+                            f"blacklist. "
+                            f"RECOMMENDED: Add '{pair}' to "
+                            f"pair_blacklist in your config file "
+                            f"for persistence."
                         )
                     else:
                         logger.error(
-                            f"⚠️  PAIR DELISTED: {pair} failed with BadSymbol {failure_count} times. "
-                            f"This pair appears to be delisted from the exchange. "
-                            f"Pair already in blacklist - no new entry attempts will be made."
+                            f"⚠️  PAIR DELISTED: {pair} failed "
+                            f"with BadSymbol {failure_count} times. "
+                            f"This pair appears to be delisted "
+                            f"from the exchange. "
+                            f"Pair already in blacklist - no new "
+                            f"entry attempts will be made."
                         )
 
                     # Raise DDosProtection to prevent infinite retry loop
@@ -448,8 +462,11 @@ class Modetrade(Exchange):
                 else:
                     # Still tracking, log progress
                     logger.warning(
-                        f"BadSymbol error for {pair} ({failure_count}/{self._bad_symbol_threshold}). "
-                        f"Will mark as delisted if this continues."
+                        f"BadSymbol error for {pair} "
+                        f"({failure_count}/"
+                        f"{self._bad_symbol_threshold}). "
+                        f"Will mark as delisted if this "
+                        f"continues."
                     )
                     # Re-raise for retry
                     raise

--- a/freqtrade/exchange/modetrade.py
+++ b/freqtrade/exchange/modetrade.py
@@ -1,19 +1,20 @@
 """Mode exchange subclass"""
 
 import logging
-from typing import Any, Dict, Optional, Set
+from typing import Any
 
 import ccxt
+
 from freqtrade.enums.marginmode import MarginMode
 from freqtrade.enums.tradingmode import TradingMode
-from freqtrade.exchange import Exchange
-from freqtrade.exchange.exchange_types import FtHas, Ticker, OrderBook
-from freqtrade.exchange.common import retrier
 from freqtrade.exceptions import (
     DDosProtection,
     OperationalException,
     TemporaryError,
 )
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.common import retrier
+from freqtrade.exchange.exchange_types import FtHas, OrderBook
 
 
 logger = logging.getLogger(__name__)
@@ -47,12 +48,12 @@ class Modetrade(Exchange):
         # "ws_enabled": True,
     }
 
-    def __init__(self, config: Dict[str, Any], *, validate: bool = True, **kwargs) -> None:
+    def __init__(self, config: dict[str, Any], *, validate: bool = True, **kwargs) -> None:
         """Initialize ModeTrade exchange with delisting detection."""
         super().__init__(config, validate=validate, **kwargs)
         # Track BadSymbol failures per pair for delisting detection
-        self._bad_symbol_count: Dict[str, int] = {}
-        self._delisted_pairs: Set[str] = set()
+        self._bad_symbol_count: dict[str, int] = {}
+        self._delisted_pairs: set[str] = set()
         # Mark pair as delisted after N consecutive BadSymbol failures
         self._bad_symbol_threshold = 3
         logger.info(
@@ -206,16 +207,16 @@ class Modetrade(Exchange):
                 # Use ticker-only pricing
                 return super().get_rate(pair, refresh, side, is_short, order_book=None, ticker=ticker)
             raise
-        
+
         # Get mark/index reference
         idx, mark, ref_err = self._get_reference_price(pair, ticker)
         ref_price = idx if idx is not None else mark
-        
+
         # Determine which price to use
         if ref_price is not None:
             deviation = self._rel_deviation(ob_rate, ref_price)
             max_dev = cfg["max_deviation_ratio"]
-            
+
             if deviation <= max_dev:
                 chosen_rate = ob_rate
                 action = "use_orderbook"
@@ -226,7 +227,7 @@ class Modetrade(Exchange):
             chosen_rate = ob_rate
             action = "use_orderbook_no_ref"
             deviation = None
-        
+
         # Log decision
         self._log_price_decision({
             "pair": pair,
@@ -242,7 +243,7 @@ class Modetrade(Exchange):
             "ref_err": ref_err,
             "log_level": cfg["log_level"],
         })
-        
+
         return chosen_rate
 
     def _get_reference_price(
@@ -261,7 +262,7 @@ class Modetrade(Exchange):
         dev_str = f"{data['deviation']:.2%}" if data['deviation'] is not None else "N/A"
         idx_str = f"{data['idx']:.6f}" if data['idx'] is not None else "N/A"
         mark_str = f"{data['mark']:.6f}" if data['mark'] is not None else "N/A"
-        
+
         msg = (
             f"ModeTrade price check: {data['action']} | "
             f"pair={data['pair']} side={data['side']} short={data['is_short']} | "
@@ -269,10 +270,10 @@ class Modetrade(Exchange):
             f"mark={mark_str} → chose={data['chosen_rate']:.6f} | "
             f"dev={dev_str} max={data['max_dev']:.1%}"
         )
-        
+
         if data['ref_err']:
             msg += f" | ref_err={data['ref_err']}"
-        
+
         getattr(logger, data['log_level'], logger.warning)(msg)
 
     # TODO: This is a spoofed with Binance data.

--- a/freqtrade/exchange/woofipro.py
+++ b/freqtrade/exchange/woofipro.py
@@ -111,7 +111,11 @@ class Woofipro(Exchange):
         for token, balance in balances.items():
             if balance["free"] is None:
                 new_balances[token]["frozen"] = float(balance["frozen"])
-                new_balances[token]["free"] = float(Decimal(balance["total"]) - Decimal(balance["frozen"]))
+                free_amount = (
+                    Decimal(balance["total"])
+                    - Decimal(balance["frozen"])
+                )
+                new_balances[token]["free"] = float(free_amount)
                 new_balances[token]["used"] = float(balance["frozen"])
         return new_balances
 

--- a/freqtrade/exchange/woofipro.py
+++ b/freqtrade/exchange/woofipro.py
@@ -5,16 +5,17 @@ from copy import deepcopy
 from decimal import Decimal
 
 import ccxt
+
 from freqtrade.enums.marginmode import MarginMode
 from freqtrade.enums.tradingmode import TradingMode
-from freqtrade.exchange import Exchange
-from freqtrade.exchange.exchange_types import CcxtBalances, FtHas
-from freqtrade.exchange.common import retrier
 from freqtrade.exceptions import (
     DDosProtection,
     OperationalException,
     TemporaryError,
 )
+from freqtrade.exchange import Exchange
+from freqtrade.exchange.common import retrier
+from freqtrade.exchange.exchange_types import CcxtBalances, FtHas
 
 
 logger = logging.getLogger(__name__)
@@ -113,7 +114,7 @@ class Woofipro(Exchange):
                 new_balances[token]["free"] = float(Decimal(balance["total"]) - Decimal(balance["frozen"]))
                 new_balances[token]["used"] = float(balance["frozen"])
         return new_balances
-    
+
     @retrier
     def _set_leverage(
         self,
@@ -127,7 +128,7 @@ class Woofipro(Exchange):
         if self._config["dry_run"] or not self.exchange_has("setLeverage"):
             # Some exchanges only support one margin_mode type
             return
-        
+
         # Orderly requires integer leverage
         leverage = int(leverage)
 

--- a/freqtrade/freqtradebot.py
+++ b/freqtrade/freqtradebot.py
@@ -207,8 +207,13 @@ class FreqtradeBot(LoggingMixin):
 
         db_open_pairs = {t.pair for t in Trade.get_trades_proxy(is_open=True)}
         # Only consider *actually open* positions.
-        # Some exchanges may return "position" entries with 0 contracts but non-zero collateral/metadata.
-        open_position_pairs = {pair for pair, pos in self.wallets.get_all_positions().items() if pos.position != 0}
+        # Some exchanges may return "position" entries with
+        # 0 contracts but non-zero collateral/metadata.
+        open_position_pairs = {
+            pair
+            for pair, pos in self.wallets.get_all_positions().items()
+            if pos.position != 0
+        }
 
 
         unknown_positions = open_position_pairs - db_open_pairs

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -8,7 +8,7 @@ import json
 import logging
 from collections import defaultdict
 from copy import deepcopy
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
 
@@ -914,7 +914,7 @@ class Backtesting:
         trade.open_rate = float(remaining_sleeve.get("avg_price") or trade.open_rate)
         opened_at = datetime.fromisoformat(remaining_sleeve["opened_at"])
         if opened_at.tzinfo is not None:
-            opened_at = opened_at.astimezone(timezone.utc).replace(tzinfo=None)
+            opened_at = opened_at.astimezone(UTC).replace(tzinfo=None)
         trade.open_date = opened_at
 
     @staticmethod

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -871,7 +871,8 @@ class Backtesting:
                 if "quantity_units" in sleeve_copy:
                     planned_units = (
                         float(planned_exit["quantity_units"])
-                        if planned_exit is not None and planned_exit.get("quantity_units") is not None
+                        if planned_exit is not None
+                        and planned_exit.get("quantity_units") is not None
                         else float(sleeve_copy["quantity_units"])
                     )
                     remaining_units = max(0.0, float(sleeve_copy["quantity_units"]) - planned_units)

--- a/freqtrade/optimize/backtesting.py
+++ b/freqtrade/optimize/backtesting.py
@@ -1404,7 +1404,7 @@ class Backtesting:
         }
 
     @staticmethod
-    def _build_phase1_net_exit_plan(
+    def _build_phase1_net_exit_plan(  # noqa: C901
         trade: LocalTrade,
         phase1_netting_exit_intents: str | None,
     ) -> dict | None:
@@ -2312,7 +2312,7 @@ class Backtesting:
             for pair in new_pairlist:
                 yield current_time_det, is_first, has_detail, idx, pair
 
-    def time_pair_generator(
+    def time_pair_generator(  # noqa: C901
         self,
         start_date: datetime,
         end_date: datetime,

--- a/freqtrade/plugins/pairlist/HistoricalVolumePairList.py
+++ b/freqtrade/plugins/pairlist/HistoricalVolumePairList.py
@@ -24,7 +24,7 @@ and trading_mode. Override pair_suffix explicitly only if needed.
 """
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 import pandas as pd
@@ -331,7 +331,7 @@ class HistoricalVolumePairList(IPairList):
         # Get current backtest time from pairlist manager
         current_time = self._pairlistmanager._current_time
         if current_time is None:
-            current_time = datetime.now(timezone.utc)
+            current_time = datetime.now(UTC)
 
         day_str = str(current_time.date())
 

--- a/freqtrade/plugins/pairlist/HistoricalVolumePairList.py
+++ b/freqtrade/plugins/pairlist/HistoricalVolumePairList.py
@@ -126,13 +126,19 @@ class HistoricalVolumePairList(IPairList):
                 "type": "string",
                 "default": "",
                 "description": "Source file pair suffix (auto-derived if empty)",
-                "help": "File naming suffix. Auto-derived from stake_currency + trading_mode if not set.",
+                "help": (
+                    "File naming suffix. Auto-derived from"
+                    " stake_currency + trading_mode if not set."
+                ),
             },
             "token_mapping": {
                 "type": "object",
                 "default": {},
                 "description": "Token name mapping",
-                "help": "Map source file token names to trading pair names (e.g. {'kPEPE': 'KPEPE'}).",
+                "help": (
+                    "Map source file token names to trading"
+                    " pair names (e.g. {'kPEPE': 'KPEPE'})."
+                ),
             },
         }
 

--- a/tests/exchange/test_delisting_detection_simple.py
+++ b/tests/exchange/test_delisting_detection_simple.py
@@ -5,10 +5,14 @@ Tests the delisting detection without needing full bot startup.
 """
 
 import sys
+
+
 sys.path.insert(0, 'deps/freqtrade')
 
 import ccxt
+
 from freqtrade.exceptions import DDosProtection, TemporaryError
+
 
 print("=" * 80)
 print("REPL TEST: BadSymbol Detection Logic")
@@ -71,7 +75,7 @@ for attempt in range(1, 5):
     try:
         print(f"   Calling fetch_l2_order_book('{test_pair}')...")
         order_book = exchange.fetch_l2_order_book(test_pair, 1)
-        print(f"   ✓ Got order book (unexpected!)")
+        print("   ✓ Got order book (unexpected!)")
     except DDosProtection as e:
         print(f"   ✓ CAUGHT DDosProtection: {e}")
     except TemporaryError as e:
@@ -82,7 +86,7 @@ for attempt in range(1, 5):
     print(f"   State: count={exchange._bad_symbol_count}, delisted={exchange._delisted_pairs}")
 
     if test_pair in exchange._delisted_pairs:
-        print(f"\n   🎯 PAIR MARKED AS DELISTED!")
+        print("\n   🎯 PAIR MARKED AS DELISTED!")
         break
 
 print("\n" + "="*80)
@@ -93,19 +97,19 @@ print(f"_delisted_pairs: {exchange._delisted_pairs}")
 
 if test_pair in exchange._delisted_pairs:
     print(f"\n✅ TEST PASSED: Logic correctly marks pair as delisted after {exchange._bad_symbol_threshold} attempts")
-    print(f"✅ Raises DDosProtection on threshold")
-    print(f"✅ Raises TemporaryError before threshold")
+    print("✅ Raises DDosProtection on threshold")
+    print("✅ Raises TemporaryError before threshold")
 else:
-    print(f"\n❌ TEST FAILED")
+    print("\n❌ TEST FAILED")
 
 print("\n" + "="*80)
 print("TESTING SUBSEQUENT CALLS TO DELISTED PAIR")
 print("="*80)
 
 try:
-    print(f"Calling fetch_l2_order_book on already-delisted pair...")
+    print("Calling fetch_l2_order_book on already-delisted pair...")
     exchange.fetch_l2_order_book(test_pair, 1)
-    print(f"❌ Should have raised DDosProtection immediately!")
+    print("❌ Should have raised DDosProtection immediately!")
 except DDosProtection as e:
     print(f"✅ Correctly raised DDosProtection immediately: {e}")
 except Exception as e:

--- a/tests/exchange/test_delisting_detection_simple.py
+++ b/tests/exchange/test_delisting_detection_simple.py
@@ -96,7 +96,11 @@ print(f"_bad_symbol_count: {exchange._bad_symbol_count}")
 print(f"_delisted_pairs: {exchange._delisted_pairs}")
 
 if test_pair in exchange._delisted_pairs:
-    print(f"\n✅ TEST PASSED: Logic correctly marks pair as delisted after {exchange._bad_symbol_threshold} attempts")
+    threshold = exchange._bad_symbol_threshold
+    print(
+        f"\n✅ TEST PASSED: Logic correctly marks pair "
+        f"as delisted after {threshold} attempts"
+    )
     print("✅ Raises DDosProtection on threshold")
     print("✅ Raises TemporaryError before threshold")
 else:

--- a/tests/exchange/test_delisting_detection_simple.py
+++ b/tests/exchange/test_delisting_detection_simple.py
@@ -54,7 +54,7 @@ class MockExchange:
                     f"(BadSymbol threshold {self._bad_symbol_threshold} reached)"
                 ) from e
             else:
-                print(f"   ℹ️  BadSymbol for {pair} ({failure_count}/{self._bad_symbol_threshold})")
+                print(f"   [i] BadSymbol for {pair} ({failure_count}/{self._bad_symbol_threshold})")
                 raise TemporaryError(
                     f"Could not get order book due to {e.__class__.__name__}. Message: {e}"
                 ) from e

--- a/tests/exchange/test_modetrade_price_sanity.py
+++ b/tests/exchange/test_modetrade_price_sanity.py
@@ -294,7 +294,10 @@ class TestModeTradeDelistingDetection:
         # Create a function that returns a new TemporaryError each time (needed for multiple raises)
         def create_temp_error():
             bad_symbol_error = ccxt.BadSymbol(f"modetrade does not have market symbol {test_pair}")
-            temp_error = TemporaryError(f"Could not get order book due to BadSymbol. Message: {bad_symbol_error}")
+            temp_error = TemporaryError(
+                "Could not get order book due to "
+                f"BadSymbol. Message: {bad_symbol_error}"
+            )
             temp_error.__cause__ = bad_symbol_error
             return temp_error
 

--- a/tests/exchange/test_modetrade_price_sanity.py
+++ b/tests/exchange/test_modetrade_price_sanity.py
@@ -1,6 +1,7 @@
 """Unit tests for ModeTrade price sanity check logic"""
 
 import pytest
+
 from freqtrade.exchange.modetrade import Modetrade
 
 
@@ -276,9 +277,11 @@ class TestModeTradeDelistingDetection:
 
     def test_badsymbol_tracking_increments(self):
         """Test that BadSymbol failures are tracked correctly"""
-        import ccxt
         from unittest.mock import patch
-        from freqtrade.exceptions import TemporaryError, DDosProtection
+
+        import ccxt
+
+        from freqtrade.exceptions import DDosProtection, TemporaryError
 
         # Create mock exchange instance
         modetrade = Modetrade({'name': 'modetrade', 'dry_run': True})
@@ -339,8 +342,10 @@ class TestModeTradeDelistingDetection:
 
     def test_successful_fetch_resets_counter(self):
         """Test that successful fetch resets the failure counter"""
-        import ccxt
         from unittest.mock import patch
+
+        import ccxt
+
         from freqtrade.exceptions import TemporaryError
 
         modetrade = Modetrade({'name': 'modetrade', 'dry_run': True})

--- a/tests/plugins/test_historical_volume_pairlist.py
+++ b/tests/plugins/test_historical_volume_pairlist.py
@@ -2,16 +2,14 @@
 Tests for HistoricalVolumePairList pairlist plugin.
 """
 
-from datetime import datetime, timezone
-from unittest.mock import MagicMock, PropertyMock
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 from freqtrade.plugins.pairlist.HistoricalVolumePairList import HistoricalVolumePairList
 from freqtrade.plugins.pairlist.IPairList import SupportsBacktesting
-from freqtrade.plugins.pairlistmanager import PairListManager
-from tests.conftest import EXMS, get_patched_exchange
 
 
 # ---------------------------------------------------------------------------
@@ -285,7 +283,7 @@ class TestFilterPairlist:
             "data_source_dir": str(volume_data_dir),
             "number_assets": 10,
         })
-        plm._current_time = datetime(2025, 1, 5, 12, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 5, 12, 0, tzinfo=UTC)
 
         # Input in arbitrary order, including a pair not in volume data
         input_list = ["DOGE/USDC:USDC", "BTC/USDC:USDC", "UNKNOWN/USDC:USDC", "ETH/USDC:USDC"]
@@ -299,7 +297,7 @@ class TestFilterPairlist:
             "data_source_dir": str(volume_data_dir),
         })
         # Date after data range — should fall back to last available date
-        plm._current_time = datetime(2025, 2, 1, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 2, 1, 0, 0, tzinfo=UTC)
 
         result = handler.filter_pairlist(["BTC/USDC:USDC", "ETH/USDC:USDC"], {})
         assert len(result) == 2
@@ -325,7 +323,7 @@ class TestFilterPairlist:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(tmp_path),
         })
-        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=UTC)
 
         input_list = ["BTC/USDC:USDC", "ETH/USDC:USDC"]
         # Empty data → empty rankings → no earlier date found → return original
@@ -337,7 +335,7 @@ class TestFilterPairlist:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(volume_data_dir),
         })
-        plm._current_time = datetime(2024, 1, 1, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2024, 1, 1, 0, 0, tzinfo=UTC)
 
         input_list = ["BTC/USDC:USDC"]
         result = handler.filter_pairlist(input_list, {})
@@ -399,7 +397,7 @@ class TestPairlistChainIntegration:
             "number_assets": 2,
             "lookback_days": 7,
         })
-        plm._current_time = datetime(2025, 1, 8, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 8, 0, 0, tzinfo=UTC)
 
         # Simulate StaticPairList output (all 3 pairs)
         static_output = ["BTC/USDC:USDC", "ETH/USDC:USDC", "DOGE/USDC:USDC"]
@@ -417,7 +415,7 @@ class TestPairlistChainIntegration:
             "data_source_dir": str(volume_data_dir),
             "number_assets": 10,
         })
-        plm._current_time = datetime(2025, 1, 8, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 8, 0, 0, tzinfo=UTC)
 
         # Input in reverse volume order
         result = handler.filter_pairlist(
@@ -609,7 +607,7 @@ class TestCaseInsensitiveMatching:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(tmp_path),
         })
-        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=UTC)
 
         # Whitelist uses uppercase KPEPE
         result = handler.filter_pairlist(["KPEPE/USDC:USDC"], {})
@@ -635,7 +633,7 @@ class TestCaseInsensitiveMatching:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(tmp_path),
         })
-        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=UTC)
 
         # Even if we pass weird casing, the result uses the input pairlist's casing
         result = handler.filter_pairlist(["BTC/USDC:USDC", "ETH/USDC:USDC"], {})
@@ -665,7 +663,7 @@ class TestCaseInsensitiveMatching:
             "data_source_dir": str(tmp_path),
             # No token_mapping!
         })
-        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=UTC)
 
         # Whitelist uses uppercase K
         whitelist = [f"{t[1:].upper()}/USDC:USDC" for t in k_tokens]
@@ -696,7 +694,7 @@ class TestCaseInsensitiveMatching:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(tmp_path),
         })
-        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 3, 0, 0, tzinfo=UTC)
 
         result = handler.filter_pairlist(
             ["KAITO/USDC:USDC", "KAS/USDC:USDC"], {}
@@ -713,7 +711,7 @@ class TestGracefulDegradation:
     def test_exception_returns_original_pairlist(self, mocker):
         """If internal logic throws, filter_pairlist returns input unchanged."""
         handler, plm = _make_handler(mocker)
-        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=UTC)
 
         # Force _build_daily_rankings to throw
         handler._build_daily_rankings = MagicMock(
@@ -729,7 +727,7 @@ class TestGracefulDegradation:
         handler, plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": "/totally/nonexistent/path",
         })
-        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=timezone.utc)
+        plm._current_time = datetime(2025, 1, 5, 0, 0, tzinfo=UTC)
 
         input_list = ["BTC/USDC:USDC"]
         # Should not raise — empty data → empty rankings → return original

--- a/tests/plugins/test_historical_volume_pairlist.py
+++ b/tests/plugins/test_historical_volume_pairlist.py
@@ -751,10 +751,10 @@ class TestGracefulDegradation:
         df.to_feather(futures_dir / "BTC_USDC_USDC-1d-futures.feather")
 
         # Write corrupted file
-        with open(futures_dir / "BAD_USDC_USDC-1d-futures.feather", "wb") as f:
+        with (futures_dir / "BAD_USDC_USDC-1d-futures.feather").open("wb") as f:
             f.write(b"not a feather file")
 
-        handler, plm = _make_handler(mocker, pairlistconfig={
+        handler, _plm = _make_handler(mocker, pairlistconfig={
             "data_source_dir": str(tmp_path),
         })
         handler._load_volume_data()

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -643,7 +643,6 @@ class TestPatchLogging:
             logger_test.setLevel(logging.DEBUG)
 
             # Create a handler that captures records (like FTBufferingHandler)
-            import io
             handler = logging.handlers.MemoryHandler(capacity=100)
             logger_test.addHandler(handler)
 

--- a/tests/test_log_setup.py
+++ b/tests/test_log_setup.py
@@ -264,21 +264,33 @@ class TestSensitiveDataFilter:
 
     def test_redacts_private_key_double_quotes(self):
         f = SensitiveDataFilter()
-        text = '{"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'
+        hex_key = (
+            "0x1234567890abcdef1234567890abcdef"
+            "1234567890abcdef1234567890abcdef"
+        )
+        text = '{"privateKey": "' + hex_key + '"}'
         result = f._sanitize(text)
         assert "[REDACTED]" in result
         assert "1234567890abcdef" not in result
 
     def test_redacts_private_key_single_quotes(self):
         f = SensitiveDataFilter()
-        text = "{'privateKey': '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef'}"
+        hex_key = (
+            "0x1234567890abcdef1234567890abcdef"
+            "1234567890abcdef1234567890abcdef"
+        )
+        text = "{'privateKey': '" + hex_key + "'}"
         result = f._sanitize(text)
         assert "[REDACTED]" in result
         assert "1234567890abcdef" not in result
 
     def test_redacts_private_key_snake_case(self):
         f = SensitiveDataFilter()
-        text = '{"private_key": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"}'
+        hex_key = (
+            "0xabcdef1234567890abcdef1234567890"
+            "abcdef1234567890abcdef1234567890"
+        )
+        text = '{"private_key": "' + hex_key + '"}'
         result = f._sanitize(text)
         assert "[REDACTED]" in result
         assert "abcdef1234567890" not in result
@@ -324,7 +336,11 @@ class TestSensitiveDataFilter:
             level=logging.INFO,
             pathname="",
             lineno=0,
-            msg='Request: {"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}',
+            msg=(
+                'Request: {"privateKey": '
+                '"0x1234567890abcdef1234567890abcdef'
+                '1234567890abcdef1234567890abcdef"}'
+            ),
             args=(),
             exc_info=None,
         )
@@ -341,7 +357,11 @@ class TestSensitiveDataFilter:
             pathname="",
             lineno=0,
             msg="Data: %s",
-            args=('{"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}',),
+            args=(
+                '{"privateKey": '
+                '"0x1234567890abcdef1234567890abcdef'
+                '1234567890abcdef1234567890abcdef"}',
+            ),
             exc_info=None,
         )
         result = f.filter(record)
@@ -352,7 +372,11 @@ class TestSensitiveDataFilter:
     def test_case_insensitive(self):
         f = SensitiveDataFilter()
         # Test case insensitivity for key names
-        text = '{"PRIVATEKEY": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'
+        hex_key = (
+            "0x1234567890abcdef1234567890abcdef"
+            "1234567890abcdef1234567890abcdef"
+        )
+        text = '{"PRIVATEKEY": "' + hex_key + '"}'
         result = f._sanitize(text)
         assert "[REDACTED]" in result
         assert "1234567890abcdef" not in result
@@ -371,7 +395,13 @@ class TestSensitiveDataFilter:
             args=None,
             exc_info=None,
         )
-        record.args = {"config": '{"privateKey": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"}'}
+        hex_key = (
+            "0x1234567890abcdef1234567890abcdef"
+            "1234567890abcdef1234567890abcdef"
+        )
+        record.args = {
+            "config": '{"privateKey": "' + hex_key + '"}'
+        }
         result = f.filter(record)
         assert result is True
         assert isinstance(record.args, dict)


### PR DESCRIPTION
## Why

The `ts-base` branch has 127 ruff lint errors inherited from upstream refactoring and our custom additions. These cause CI to fail on **every PR**, including security-critical ones like #8.

Resolves https://github.com/tradingstrategy-ai/freqtrade-strategies/issues/159

## What was fixed

### Commit 1: Auto-fix (68 errors)
Mechanical fixes via `ruff check --fix`:
- **Import sorting** (I001): 9 files had unsorted imports
- **Unused imports** (F401): Removed 8 unused imports (`format_ms_time`, `PropertyMock`, `PairListManager`, `EXMS`, `get_patched_exchange`, `Optional`, `Ticker`, `io`)
- **f-strings without placeholders** (F541): 7 print statements in `test_delisting_detection_simple.py` converted to plain strings
- **Duplicate imports** (F811): `Modetrade` and `Okx` were imported twice in `__init__.py`
- **Whitespace** (W291/W292/W293): 13 trailing whitespace and missing newlines in `modetrade.py`, `woofipro.py`, `metrics.py`
- **Type annotations** (UP006/UP017/UP041): `Dict`→`dict`, `Set`→`set`, `timezone.utc`→`UTC`, `asyncio.TimeoutError`→`TimeoutError`

### Commit 2: E501 in exchange_ws.py (29 lines)
Line-length fixes by splitting lines — no logic changes:
- Long logger f-strings split across implicit string concatenation
- Chained `.get()` fallbacks wrapped in parentheses
- List comprehensions wrapped across lines
- Long conditions wrapped in parentheses

### Commit 3: E501 in 9 other files (22 lines)
Same pattern — split long lines:
- `modetrade.py`: Wrapped `super().get_rate()` params and log messages
- `exchange.py`: Wrapped wallet address config fallback chain
- `woofipro.py`: Extracted Decimal arithmetic to intermediate variable
- `freqtradebot.py`: Split comment and set comprehension
- `backtesting.py`: Split long ternary condition
- `HistoricalVolumePairList.py`: Wrapped help strings
- Test files: Extracted long hex strings to variables, split assertions

### Commit 4: Non-trivial fixes (16 errors)
- **C901 complexity** (3): Added `# noqa: C901` to `_continuously_async_watch_ohlcv`, `_build_phase1_net_exit_plan`, `time_pair_generator` — per constraint to prefer noqa over refactoring for upstream-inherited complexity
- **S110 bare except** (1): Added `# noqa: S110` to best-effort `close()` in cleanup path
- **RUF006 untracked task** (1): Stored `asyncio.create_task()` result in `self._background_tasks` with done callback — prevents GC of fire-and-forget failure handler
- **F841 unused variables** (2): Removed dead `near_boundary` computation in `exchange_ws.py` and unused `name` assignment in `grvt.py`
- **S101 assert** (4): Added `# noqa: S101` to runtime guards in `aster.py`; replaced `assert` with `raise OperationalException` in `grvt.py` (2 locations)
- **RUF001 ambiguous unicode** (1): Replaced `ℹ️` with `[i]` in test output
- **PTH123 open()** (1): Changed `open(path)` to `path.open()` in test
- **RUF059 unused unpack** (1): Renamed `plm` to `_plm` in test

## Functionality impact assessment

**Two changes touch behavior:**

1. **`grvt.py` assert→exception**: `assert sync` and `assert "api_key"` replaced with `if not ...: raise OperationalException(...)`. This is **safer** — asserts are stripped with `python -O`, so the old code silently accepted invalid configs in optimized mode. The new code always validates. Same error semantics (crash on invalid input), just more robust.

2. **`exchange_ws.py` RUF006 task tracking**: The fire-and-forget `asyncio.create_task(self._handle_ip_failure(...))` is now stored in `self._background_tasks` with a done callback. This **prevents premature garbage collection** of the task — the old code had a subtle bug where the task could be GC'd before completion. The done callback auto-removes it when finished.

**Everything else is purely cosmetic** — line splits, import reordering, whitespace, noqa annotations, type annotation modernization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)