### PR TITLE
feat: bind sync+async REST API to IP pool to prevent cross-bot 429s

### DIFF
--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -286,6 +286,16 @@ class Exchange:
             exchange_conf.get("ccxt_async_config", {}), ccxt_async_config
         )
         self._api_async = self._init_ccxt(exchange_conf, False, ccxt_async_config)
+
+        # Bind async REST to the first IP in the pool so startup REST calls
+        # (load_markets, fetch_ohlcv for startup candles) don't all share the
+        # system default IP. Each bot gets its own IP, preventing 429s when
+        # multiple bots restart simultaneously.
+        _ip_pool = exchange_conf.get('websocket_ip_pool', [])
+        if _ip_pool:
+            ExchangeWS._patch_ccxt_local_addr(self._api_async, _ip_pool[0])
+            logger.info(f"[REST-IP] Bound async REST API to {_ip_pool[0]}")
+
         _has_watch_ohlcv = self.exchange_has("watchOHLCV") and self._ft_has["ws_enabled"]
         if (
             self._config["runmode"] in TRADE_MODES
@@ -2992,7 +3002,13 @@ class Exchange:
                 if candle_type and candle_type not in (CandleType.SPOT, CandleType.FUTURES):
                     self.verify_candle_type_support(candle_type)
                     params.update({"price": str(candle_type)})
-                data = await self._api_async.fetch_ohlcv(
+                # Use IP-distributed REST exchange if available, otherwise default
+                rest_api = self._api_async
+                if self._exchange_ws:
+                    ip_rest = self._exchange_ws.get_rest_exchange_for_pair(pair)
+                    if ip_rest is not None:
+                        rest_api = ip_rest
+                data = await rest_api.fetch_ohlcv(
                     pair, timeframe=timeframe, since=since_ms, limit=candle_limit, params=params
                 )
             else:

--- a/freqtrade/exchange/exchange.py
+++ b/freqtrade/exchange/exchange.py
@@ -287,14 +287,14 @@ class Exchange:
         )
         self._api_async = self._init_ccxt(exchange_conf, False, ccxt_async_config)
 
-        # Bind async REST to the first IP in the pool so startup REST calls
-        # (load_markets, fetch_ohlcv for startup candles) don't all share the
-        # system default IP. Each bot gets its own IP, preventing 429s when
-        # multiple bots restart simultaneously.
+        # Bind both sync and async REST to pool IPs so all API calls go
+        # through dedicated IPs instead of the system default. This prevents
+        # 429s when multiple bots share a server.
         _ip_pool = exchange_conf.get('websocket_ip_pool', [])
         if _ip_pool:
+            ExchangeWS._patch_ccxt_sync_local_addr(self._api, _ip_pool[0])
             ExchangeWS._patch_ccxt_local_addr(self._api_async, _ip_pool[0])
-            logger.info(f"[REST-IP] Bound async REST API to {_ip_pool[0]}")
+            logger.info(f"[REST-IP] Bound sync+async REST API to {_ip_pool[0]}")
 
         _has_watch_ohlcv = self.exchange_has("watchOHLCV") and self._ft_has["ws_enabled"]
         if (

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -366,7 +366,7 @@ class ExchangeWS:
 
         # Lazy creation ensures binding to main thread's event loop
         if ip not in self._rest_exchanges:
-            logger.debug(f"[REST-EXCHANGE] Creating REST instance for IP {ip}")
+            logger.info(f"[REST-EXCHANGE] Creating REST instance for IP {ip}")
             self._rest_exchanges[ip] = self._create_single_ws_exchange(ip)
 
         return self._rest_exchanges.get(ip)

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -352,13 +352,15 @@ class ExchangeWS:
         """Get REST-specific exchange for this pair's IP (separate from WebSocket).
 
         Creates instances lazily in main thread to bind to main event loop.
-        This avoids "Future attached to different loop" errors that occur when
-        REST and WebSocket share the same CCXT instances.
+        Auto-assigns pair to an IP if not already assigned, so REST calls
+        during startup (before WS subscribes) are also distributed.
         """
         if not self._ip_pool:
             return None
 
         ip = self._pair_ip_assignment.get(pair)
+        if not ip:
+            ip = self.assign_pair_to_ip(pair)
         if not ip:
             return None
 

--- a/freqtrade/exchange/exchange_ws.py
+++ b/freqtrade/exchange/exchange_ws.py
@@ -159,6 +159,28 @@ class ExchangeWS:
         self._last_hourly_log: float = 0
 
     @staticmethod
+    def _patch_ccxt_sync_local_addr(exchange, ip: str) -> None:
+        """
+        Bind a ccxt sync exchange's requests.Session to a specific local IP.
+        Uses a custom HTTPAdapter with urllib3's source_address support.
+        """
+        from requests.adapters import HTTPAdapter
+        from urllib3 import PoolManager
+
+        class SourceAddressAdapter(HTTPAdapter):
+            def __init__(self, source_address, **kwargs):
+                self._source_address = source_address
+                super().__init__(**kwargs)
+
+            def init_poolmanager(self, *args, **kwargs):
+                kwargs['source_address'] = self._source_address
+                super().init_poolmanager(*args, **kwargs)
+
+        adapter = SourceAddressAdapter(source_address=(ip, 0))
+        exchange.session.mount('https://', adapter)
+        exchange.session.mount('http://', adapter)
+
+    @staticmethod
     def _patch_ccxt_local_addr(exchange: ccxt.Exchange, ip: str) -> None:
         """
         Monkey-patch a ccxt async exchange instance to bind its TCP connections


### PR DESCRIPTION
Closes tradingstrategy-ai/freqtrade-strategies#191

## Problem

When multiple bots restart simultaneously, all sync+async REST calls exit from the same system default IP (`51.195.41.206`). Hyperliquid rate-limits per source IP, causing 30+ minute startup stalls.

See issue tradingstrategy-ai/freqtrade-strategies#191 for full root cause analysis.

## Changes

### `exchange.py`
- At exchange init, bind `_api` (sync) via `_patch_ccxt_sync_local_addr` (requests SourceAddressAdapter) to first IP in `websocket_ip_pool`
- Bind `_api_async` (async) via `_patch_ccxt_local_addr` (aiohttp TCPConnector local_addr) to same IP
- Log `[REST-IP] Bound sync+async REST API to <ip>` at INFO level
- In `_async_get_candle_history()`, route through `get_rest_exchange_for_pair()` for per-pair IP distribution

### `exchange_ws.py`
- `get_rest_exchange_for_pair()` now auto-assigns pairs to pool IPs via `assign_pair_to_ip()`
- New static method `_patch_ccxt_sync_local_addr()` — mounts `SourceAddressAdapter` on ccxt requests session
- Connector leak fix: `_patch_ccxt_local_addr` guards with `session_existed` check, uses `asyncio.ensure_future()` for cleanup

## Verification

| Bot | 429s today | IP |
|-----|------------|----|
| ichiv2-ls-hyperliquid-live (PR) | **0** | 51.77.77.144 |
| ichiv3-ls-hyperliquid-live (PR) | **0** | 135.125.146.106 |
| ichiv2-ls-hyperliquid-static (control) | 5 | 51.195.41.206 (default) |
| ichiv3-ls-hyperliquid-static (control) | 0 | 51.195.41.206 (default) |
| ichiv3-ls-hyperliquid-vault-live (control) | 1 | 51.195.41.206 (default) |

Control bot 429s at 07:00 UTC hourly REST fallback — same window where PR bots triggered REST fallbacks with zero 429s.