### PR TITLE
fix: handle Aster -4046 NoChange in set_margin_mode gracefully

### DIFF
--- a/freqtrade/exchange/aster.py
+++ b/freqtrade/exchange/aster.py
@@ -86,6 +86,33 @@ class Aster(Exchange):
             return self._config.get("proxy_coin", self._config["stake_currency"])
         return self._config["stake_currency"]
 
+    def set_margin_mode(
+        self,
+        pair: str,
+        margin_mode: MarginMode,
+        accept_fail: bool = False,
+        params: dict | None = None,
+    ):
+        """
+        Set the margin mode for a pair on Aster.
+
+        Overrides the base implementation to treat Aster's -4046 "No need to change
+        margin type" response as a no-op rather than a fatal error. Aster always returns
+        this code when the margin mode is already set to the requested value, which is the
+        normal state for any pair the bot has previously traded.
+        """
+        try:
+            super().set_margin_mode(pair, margin_mode, accept_fail=accept_fail, params=params)
+        except TemporaryError as e:
+            if "NoChange" in str(e) or "No need to change margin type" in str(e):
+                # Aster returns code -4046 when the margin mode is already correctly set.
+                # This is expected on repeated trades on the same pair — not an error.
+                logger.debug(
+                    "Aster: margin mode already set correctly for %s (NoChange), continuing.", pair
+                )
+                return
+            raise
+
     def get_tickers(
         self,
         symbols: list[str] | None = None,

--- a/tests/exchange/test_aster.py
+++ b/tests/exchange/test_aster.py
@@ -1,0 +1,58 @@
+from unittest.mock import MagicMock, PropertyMock
+
+import ccxt
+import pytest
+
+from freqtrade.enums import MarginMode
+from freqtrade.exceptions import TemporaryError
+from tests.conftest import get_patched_exchange
+
+
+def _make_aster(mocker, conf):
+    """Return a patched Aster exchange instance with setMarginMode capability."""
+    api_mock = MagicMock()
+    type(api_mock).has = PropertyMock(return_value={"setMarginMode": True})
+    conf["dry_run"] = False
+    return get_patched_exchange(mocker, conf, api_mock, exchange="aster"), api_mock
+
+
+def test_set_margin_mode_nochange_is_ignored(mocker, default_conf):
+    """Aster -4046 NoChange must be treated as success, not a TemporaryError."""
+    exchange, api_mock = _make_aster(mocker, default_conf)
+
+    api_mock.set_margin_mode = MagicMock(side_effect=ccxt.NoChange("No need to change margin type"))
+
+    # Should not raise — NoChange means the mode is already correctly set.
+    exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED)
+
+
+def test_set_margin_mode_nochange_accept_fail_also_ignored(mocker, default_conf):
+    """NoChange is ignored regardless of accept_fail value."""
+    exchange, api_mock = _make_aster(mocker, default_conf)
+
+    api_mock.set_margin_mode = MagicMock(side_effect=ccxt.NoChange("No need to change margin type"))
+
+    exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED, accept_fail=True)
+    exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED, accept_fail=False)
+
+
+def test_set_margin_mode_other_errors_still_raise(mocker, default_conf):
+    """Non-NoChange TemporaryErrors must still propagate."""
+    exchange, api_mock = _make_aster(mocker, default_conf)
+
+    api_mock.set_margin_mode = MagicMock(
+        side_effect=ccxt.OperationRejected("Some other rejection")
+    )
+
+    with pytest.raises(TemporaryError):
+        exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED)
+
+
+def test_set_margin_mode_success_unchanged(mocker, default_conf):
+    """Normal successful set_margin_mode call still works."""
+    exchange, api_mock = _make_aster(mocker, default_conf)
+
+    api_mock.set_margin_mode = MagicMock(return_value={"code": 200})
+
+    exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED)
+    assert api_mock.set_margin_mode.call_count == 1

--- a/tests/exchange/test_aster.py
+++ b/tests/exchange/test_aster.py
@@ -40,9 +40,7 @@ def test_set_margin_mode_other_errors_still_raise(mocker, default_conf):
     """Non-NoChange TemporaryErrors must still propagate."""
     exchange, api_mock = _make_aster(mocker, default_conf)
 
-    api_mock.set_margin_mode = MagicMock(
-        side_effect=ccxt.OperationRejected("Some other rejection")
-    )
+    api_mock.set_margin_mode = MagicMock(side_effect=ccxt.OperationRejected("Some other rejection"))
 
     with pytest.raises(TemporaryError):
         exchange.set_margin_mode("BTC/USDT:USDT", MarginMode.ISOLATED)


### PR DESCRIPTION
## Why

Aster returns `{"code":-4046,"msg":"No need to change margin type."}` (ccxt `NoChange`) for every `setMarginMode` call when the account margin mode is already correctly configured — including first-time entries on pairs never previously traded. This is normal exchange behaviour, not an error.

The base `Exchange.set_margin_mode()` catches `ccxt.OperationRejected` (parent of `NoChange`) and re-raises as `TemporaryError` when `accept_fail=False`. For initial orders `accept_fail=False`, so every entry attempt fails. No pairlock is created, so the bot retries every 15 s in an infinite loop.

**Impact:** ~12,178 blocked trade signals over 16 days (2026-03-30 to 2026-04-14) after the `2025.9-dev` → `2026.2` upgrade. Live entries dropped from ~3/day to near zero.

## Summary

Override `set_margin_mode` in `Aster(Exchange)` to catch `TemporaryError` wrapping `NoChange` and return silently. "No change needed" means the margin mode is already correct — order placement should proceed normally. Fix is at the freqtrade layer so it is ccxt-version-agnostic.

## Lessons learnt

When `set_margin_mode` raises `TemporaryError`, no pairlock is created, so freqtrade retries the signal every 15 s, generating thousands of "Unable to create trade" log lines/day that mask the true signal rate.